### PR TITLE
chore(ci): add release workflow

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,0 +1,47 @@
+name: ci-release
+
+on:
+  workflow_dispatch:
+  release:
+    types: [ published ]
+
+# we do not want more than one release workflow executing at the same time, ever
+concurrency:
+  group: release
+  # cancelling in the middle of a release would create incomplete releases
+  # so cancel-in-progress is false
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: release boring-semantic-layer to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - run: uv build
+
+      - name: test (wheel)
+        run: uv run --isolated --no-project -p 3.12 --with dist/*.whl pytest tests
+
+      - name: test (source distribution)
+        run: uv run --isolated --no-project -p 3.12 --with dist/*.tar.gz pytest tests
+
+      - name: publish package
+        run: uv publish --trusted-publishing always


### PR DESCRIPTION
This PR requires enabling trusted publishing (the modern way to publish to PyPI):

- uv's side: https://docs.astral.sh/uv/guides/publish/
- PyPI's side: https://docs.pypi.org/trusted-publishers/ 

Additionally, the workflow is triggered by the creation of [GitHub Release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)

closes #22