### PR TITLE
Adding dimension and measure descriptions with backwards compatibility 

### DIFF
--- a/examples/example_basic.yml
+++ b/examples/example_basic.yml
@@ -1,32 +1,58 @@
 carriers:
+  description: "Airline carrier information including code and display names"
   table: carriers_tbl
   primary_key: code
-  
+
   dimensions:
-    code: _.code
-    name: _.name
-    nickname: _.nickname
-    
+    code:
+      expr: _.code
+      description: "IATA airline code"
+    name:
+      expr: _.name
+      description: "Airline name"
+    nickname:
+      expr: _.nickname
+      description: "Common airline nickname or brand name"
+
   measures:
-    carrier_count: _.count()
+    carrier_count:
+      expr: _.count()
+      description: "Total number of carriers"
 
 flights:
+  description: "Flight operations data with timing, routing, and performance metrics"
   table: flights_tbl
   time_dimension: arr_time
   smallest_time_grain: TIME_GRAIN_SECOND
-  
+
   dimensions:
-    origin: _.origin
-    destination: _.destination
-    carrier: _.carrier
-    tail_num: _.tail_num
-    arr_time: _.arr_time
-    
+    origin:
+      expr: _.origin
+      description: "Airport code of the departure airport (IATA 3-letter code)"
+    destination:
+      expr: _.destination
+      description: "Airport code of the arrival airport (IATA 3-letter code)"
+    carrier:
+      expr: _.carrier
+      description: "IATA airline carrier code"
+    tail_num:
+      expr: _.tail_num
+      description: "Tail number of the aircraft"
+    arr_time:
+      expr: _.arr_time
+      description: "Actual arrival time of the flight"
+
   measures:
-    flight_count: _.count()
-    avg_dep_delay: _.dep_delay.mean()
-    avg_distance: _.distance.mean()
-    
+    flight_count:
+      expr: _.count()
+      description: "Total number of flights"
+    avg_dep_delay:
+      expr: _.dep_delay.mean()
+      description: "Average departure delay in minutes"
+    avg_distance:
+      expr: _.distance.mean()
+      description: "Average distance of flights in miles"
+
   joins:
     carriers:
       model: carriers

--- a/src/boring_semantic_layer/semantic_model.py
+++ b/src/boring_semantic_layer/semantic_model.py
@@ -19,7 +19,6 @@ import datetime
 
 from boring_semantic_layer.specs import DimensionSpec, MeasureSpec
 from ibis.expr.api import desc
-from numpy import resize
 
 if TYPE_CHECKING:
     import altair

--- a/src/boring_semantic_layer/semantic_model.py
+++ b/src/boring_semantic_layer/semantic_model.py
@@ -17,6 +17,10 @@ from typing import (
 )
 import datetime
 
+from boring_semantic_layer.specs import DimensionSpec, MeasureSpec
+from ibis.expr.api import desc
+from numpy import resize
+
 if TYPE_CHECKING:
     import altair
 
@@ -36,8 +40,8 @@ _ = ibis_mod._
 How = Literal["inner", "left", "cross"]
 Cardinality = Literal["one", "many", "cross"]
 
-Dimension = Callable[[Expr], Expr]
-Measure = Callable[[Expr], Expr]
+Dimension = DimensionSpec
+Measure = MeasureSpec
 
 TimeGrain = Literal[
     "TIME_GRAIN_YEAR",
@@ -467,6 +471,29 @@ def _compile_query(qe) -> Expr:
 
     return result
 
+def _convert_dimensions(dimension_dict) -> dict:
+    """Convert plain callables to DimensionSpec with no description for backward compatibility."""
+    result = {}
+    for name, dim in dimension_dict.items():
+        if isinstance(dim, DimensionSpec):
+            result[name] = dim
+        elif callable(dim):
+            result[name] = DimensionSpec(expr=dim, description="")
+        else:
+            raise ValueError(f"Invalid dimension specification for {name}: {dim}. Must be a callable or DimensionSpec instance.")
+    return result
+
+def _convert_measures(measure_dict) -> dict:
+    """Convert plain callables to MeasureSpec with no description for backward compatibility."""
+    result = {}
+    for name, measure in measure_dict.items():
+        if isinstance(measure, MeasureSpec):
+            result[name] = measure
+        elif callable(measure):
+            result[name] = MeasureSpec(expr=measure, description="")
+        else:
+            raise ValueError(f"Invalid measure specification for {name}: {measure}. Must be a callable or MeasureSpec instance.")
+    return result
 
 def _detect_chart_spec(
     dimensions: List[str],
@@ -907,15 +934,16 @@ class SemanticModel:
 
     table: Expr = field()
     dimensions: Mapping[str, Dimension] = field(
-        converter=lambda d: MappingProxyType(dict(d))
+        converter=lambda d: MappingProxyType(_convert_dimensions(d))
     )
     measures: Mapping[str, Measure] = field(
-        converter=lambda m: MappingProxyType(dict(m))
+        converter=lambda m: MappingProxyType(_convert_measures(m))
     )
     joins: Mapping[str, Join] = field(
         converter=lambda j: MappingProxyType(dict(j or {})),
         default=MappingProxyType({}),
     )
+    description: Optional[str] = field(default=None)
     primary_key: Optional[str] = field(default=None)
     name: Optional[str] = field(default=None)
     time_dimension: Optional[str] = field(default=None)
@@ -1205,12 +1233,38 @@ class SemanticModel:
         return models
 
     @classmethod
-    def _parse_expressions(cls, expressions: Dict[str, str]) -> Dict[str, Callable]:
-        """Parse dimension or measure expressions."""
+    def _parse_expressions(cls, expressions: Dict[str, Union[str, Dict[str, str]]], spec_class) -> Dict[str, Callable]:
+        """Parse dimension or measure expressions, creating appropriate spec objects.
+
+        Supports both formats:
+        - Simple String format (backward compatible): {"name": "_.column"}
+        - Dictionary format with descriptions: {"name": {"expr": "_.column", "description": "Column description"}}
+
+        Args:
+            expressions: Dictionary of expressions to parse in either format.
+            spec_class: Either a DimensionSpec or a MeasureSpec class to create.
+
+        Returns:
+            Dictionary mapping names to spec objects.
+        """
         result = {}
-        for name, expr_str in expressions.items():
+        for name, config in expressions.items():
+            if isinstance(config, str):
+                expr_str = config
+                description = ""
+            elif isinstance(config, dict):
+                expr_str = config.get("expr")
+                if not expr_str:
+                    raise ValueError(f"Expression '{name}' must have 'expr' field when using dict format")
+                description = config.get("description", "")
+            else:
+                raise ValueError(f"Expression '{name}' must be either a string or a dictionary with 'expr' field")
+
             deferred = eval(expr_str, {"_": ibis_mod._, "__builtins__": {}})
-            result[name] = lambda t, d=deferred: d.resolve(t)
+            result[name] = spec_class(
+                expr=lambda t, d=deferred: d.resolve(t), description=description
+            )
+
         return result
 
     @classmethod
@@ -1321,6 +1375,9 @@ class SemanticModel:
             "measures": self.available_measures,
         }
 
+        if self.description:
+            definition["description"] = self.description
+
         # Add time dimension info if present
         if self.time_dimension:
             definition["time_dimension"] = self.time_dimension
@@ -1328,6 +1385,36 @@ class SemanticModel:
         # Add smallest time grain if present
         if self.smallest_time_grain:
             definition["smallest_time_grain"] = self.smallest_time_grain
+
+        # Extract dimension descriptions from spec objects
+        dimension_descriptions = {}
+        for name, dim_spec in self.dimensions.items():
+            if hasattr(dim_spec, "description"):
+                dimension_descriptions[name] = dim_spec.description
+
+        # Include joined model dimension descriptions
+        for alias, join in self.joins.items():
+            for name, dim_spec in join.model.dimensions.items():
+                if hasattr(dim_spec, "description"):
+                    dimension_descriptions[f"{alias}.{name}"] = dim_spec.description
+
+        if dimension_descriptions:
+            definition["dimension_descriptions"] = dimension_descriptions
+
+        # Extract measure descriptions from spec objects
+        measure_descriptions = {}
+        for name, measure_spec in self.measures.items():
+            if hasattr(measure_spec, "description"):
+                measure_descriptions[name] = measure_spec.description
+
+        # Include joined model measure descriptions
+        for alias, join in self.joins.items():
+            for name, measure_spec in join.model.measures.items():
+                if hasattr(measure_spec, "description"):
+                    measure_descriptions[f"{alias}.{name}"] = measure_spec.description
+
+        if measure_descriptions:
+            definition["measure_descriptions"] = measure_descriptions
 
         return definition
 
@@ -1518,7 +1605,7 @@ try:
                     Optional[Union[Dict, List[Dict]]],
                     """
                     List of JSON filter objects with the following structure:
-                       
+
                     Simple Filter:
                     {
                         "field": "dimension_name",  # Must be an existing dimension (check model schema first!).
@@ -1527,7 +1614,7 @@ try:
                         # OR for 'in'/'not in' operators only:
                         "values": ["val1", "val2"]  # REQUIRED for 'in' and 'not in' operators
                     }
-                    
+
                     IMPORTANT OPERATOR GUIDELINES:
                     - Equality: Use "=" (preferred), "eq", or "equals" - all work identically
                     - Text matching: Use "ilike" (case-insensitive) instead of "like" for better results
@@ -1535,26 +1622,26 @@ try:
                     - Negated list: "not in" requires "values" field (array), NOT "value"
                     - Pattern matching: "ilike" and "not ilike" support wildcards (%, _)
                     - Null checks: "is null" and "is not null" need no value/values field
-                    
+
                     Available operators:
                     - "=" / "eq" / "equals": exact match (use "value")
-                    - "!=": not equal (use "value") 
+                    - "!=": not equal (use "value")
                     - ">", ">=", "<", "<=": comparisons (use "value")
                     - "in": value is in list (use "values" array)
                     - "not in": value not in list (use "values" array)
                     - "ilike": case-insensitive pattern match (use "value" with % wildcards)
-                    - "not ilike": negated case-insensitive pattern (use "value" with % wildcards)  
+                    - "not ilike": negated case-insensitive pattern (use "value" with % wildcards)
                     - "like": case-sensitive pattern match (use "value" with % wildcards)
                     - "not like": negated case-sensitive pattern (use "value" with % wildcards)
                     - "is null": field is null (no value/values needed)
                     - "is not null": field is not null (no value/values needed)
-                    
+
                     COMMON MISTAKES TO AVOID:
                     1. Don't use "value" with "in"/"not in" - use "values" array instead
                     2. Don't filter on measures - only filter on dimensions
                     3. Don't use .month(), .year() etc. - use time_grain parameter instead
                     4. For case-insensitive text search, prefer "ilike" over "like"
-                       
+
                     Compound Filter (AND/OR):
                     {
                         "operator": "AND",          # or "OR"
@@ -1576,7 +1663,7 @@ try:
                             }
                         ]
                     }
-                       
+
                     Example filters:
                     [
                         {"field": "status", "operator": "in", "values": ["active", "pending"]},
@@ -1612,7 +1699,7 @@ try:
                             "start": "2024-01-01T00:00:00Z",  # ISO 8601 format
                             "end": "2024-12-31T23:59:59Z"     # ISO 8601 format
                         }
-                        
+
                         Using time_range is preferred over using filters for time-based filtering because:
                         1. It automatically applies to the model's primary time dimension
                         2. It ensures proper time zone handling with ISO 8601 format
@@ -1634,16 +1721,16 @@ try:
                         ]
                     ],
                     """Time grain for aggregating time-based dimensions.
-                    
+
                     IMPORTANT: Instead of trying to use .month(), .year(), .quarter() etc. in filters,
-                    use this time_grain parameter to aggregate by time periods. The system will 
+                    use this time_grain parameter to aggregate by time periods. The system will
                     automatically handle time dimension transformations.
-                    
+
                     Examples:
-                    - For monthly data: time_grain="TIME_GRAIN_MONTH" 
+                    - For monthly data: time_grain="TIME_GRAIN_MONTH"
                     - For yearly data: time_grain="TIME_GRAIN_YEAR"
                     - For daily data: time_grain="TIME_GRAIN_DAY"
-                    
+
                     Then filter using the time_range parameter or regular date filters like:
                     {"field": "date_column", "operator": ">=", "value": "2024-01-01"}
                     """,
@@ -1656,17 +1743,17 @@ try:
                     - Dict: Returns {"records": [...], "chart": {...}} with custom Vega-Lite specification
                       Can be partial (e.g., just {"mark": "line"} or {"encoding": {"y": {"scale": {"zero": False}}}}).
                       BSL intelligently merges partial specs with auto-detected defaults.
-                    
+
                     Common chart specifications:
                     - {"mark": "bar"} - Bar chart
-                    - {"mark": "line"} - Line chart  
+                    - {"mark": "line"} - Line chart
                     - {"mark": "point"} - Scatter plot
                     - {"mark": "rect"} - Heatmap
                     - {"title": "My Chart"} - Add title
                     - {"width": 600, "height": 400} - Set size
                     - {"encoding": {"color": {"field": "category"}}} - Color by field
                     - {"encoding": {"y": {"scale": {"zero": False}}}} - Don't start Y-axis at zero
-                    
+
                     BSL auto-detection logic:
                     - Time series (time dimension + measure) → Line chart
                     - Categorical (1 dimension + 1 measure) → Bar chart

--- a/src/boring_semantic_layer/specs.py
+++ b/src/boring_semantic_layer/specs.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+from typing import Callable
+
+from xorq.caching import frozen
+
+try:
+    import xorq.vendor.ibis as ibis_mod
+
+    IS_XORQ_USED = True
+except ImportError:
+    import ibis as ibis_mod
+    IS_XORQ_USED = False
+
+Expr = ibis_mod.expr.types.core.Expr
+
+@dataclass(frozen=True)
+class DimensionSpec:
+    expr: Callable[[Expr], Expr]
+    description: str
+
+    def __call__(self, table: Expr) -> Expr:
+        return self.expr(table)
+
+@dataclass(frozen=True)
+class MeasureSpec:
+    expr: Callable[[Expr], Expr]
+    description: str
+
+    def __call__(self, table: Expr) -> Expr:
+        return self.expr(table)

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -1,0 +1,101 @@
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from boring_semantic_layer.specs import DimensionSpec, MeasureSpec
+from xorq import desc
+
+class TestDimensionSpec:
+    def test_dimension_spec_creation(self):
+        expr_func = lambda table: table.column_name
+        description = "Test Dimension"
+
+        dim_spec = DimensionSpec(expr_func, description)
+
+        assert dim_spec.expr == expr_func
+        assert dim_spec.description == description
+
+    def test_dimension_spec_is_frozen(self):
+        expr_func = lambda table: table.column_name
+        description = "Test Dimension"
+
+        dim_spec = DimensionSpec(expr_func, description)
+
+        with pytest.raises(AttributeError):
+            dim_spec.expr = lambda table: table.column_name + 1
+
+        with pytest.raises(AttributeError):
+            dim_spec.description = "New Description"
+
+    def test_dimension_spec_call(self):
+        mock_table = Mock()
+        mock_result = Mock()
+        expr_func = Mock(return_value=mock_result)
+
+        dim_spec = DimensionSpec(expr=expr_func, description="Test Dimension")
+        result = dim_spec(mock_table)
+
+        expr_func.assert_called_once_with(mock_table)
+        assert result == mock_result
+
+    def test_dimension_spec_equality(self):
+        expr_func = lambda table: table.column_name
+        description = "Test Dimension"
+
+        dim_spec1 = DimensionSpec(expr_func, description)
+        dim_spec2 = DimensionSpec(expr_func, description)
+
+        assert dim_spec1 == dim_spec2
+
+class TestMeasureSpec:
+    def test_measure_spec_creation(self):
+        expr_func = lambda table: table.column_name
+        description = "Test Measure"
+
+        measure_spec = MeasureSpec(expr_func, description)
+
+        assert measure_spec.expr == expr_func
+        assert measure_spec.description == description
+
+    def test_measure_spec_is_frozen(self):
+        expr_func = lambda table: table.column_name
+        description = "Test Measure"
+
+        measure_spec = MeasureSpec(expr_func, description)
+
+        with pytest.raises(AttributeError):
+            measure_spec.expr = lambda table: table.column_name + 1
+
+        with pytest.raises(AttributeError):
+            measure_spec.description = "New Description"
+
+    def test_measure_spec_call(self):
+        mock_table = Mock()
+        mock_result = Mock()
+        expr_func = Mock(return_value=mock_result)
+
+        measure_spec = MeasureSpec(expr=expr_func, description="Test Measure")
+        result = measure_spec(mock_table)
+
+        expr_func.assert_called_once_with(mock_table)
+        assert result == mock_result
+
+    def test_measure_spec_equality(self):
+        expr_func = lambda table: table.column_name
+        description = "Test Measure"
+
+        measure_spec1 = MeasureSpec(expr_func, description)
+        measure_spec2 = MeasureSpec(expr_func, description)
+
+        assert measure_spec1 == measure_spec2
+
+class TestSpecInteraction:
+    def test_specs_work_with_ibis_expressions(self):
+        mock_table = MagicMock()
+        mock_column = MagicMock()
+        mock_table.customer_id = mock_column
+
+        dim_spec = DimensionSpec(expr=lambda table: table.customer_id, description="Customer ID")
+        result = dim_spec(mock_table)
+
+        assert result == mock_column


### PR DESCRIPTION
While I have been using BSL, with Claude code, I have been very impressed, however have quickly noticed the agent makes guesses about the correct semantic model to use as the number of models is growing. Lets take a hypothetical example:

Semantic Model: User Sales
Semantic Model: User Activity

Both use user data, but show very different things. If I want a count of the number of users in my system, the agent might use 'User Count' from either of these SM's - but they may show different numbers. For example for a user to exist let's assume they have to sign up = an activity. Every user should have at least one activity, but not every user could have made a sale - we'd quickly start to diverge.

This is where agents need extra context, just like humans, hence descriptions.

I propose the adoption of two 'specs' - though they are the same in nature right now, they may end up with different attributes and methods as time goes on - perhaps an abstract base class would be a good alternative if in the first instance that this happens.

The format of these specs:

- DimensionSpec: 
&nbsp;&nbsp;- expr (the existing ibis compliant lambda expression)
&nbsp;&nbsp;- description (the, ideally, detailed description of the dimension and if practical its possible values)

- MeasureSpec: 
&nbsp;&nbsp;- expr (the existing ibis compliant lambda expression)
&nbsp;&nbsp;- description (the, ideally, detailed description of the measure and any other context about it that would improve the agents understanding)

Changes:

- specs.py: This is where the two specs have been created and are imported from
- example_basic.yml: the yaml definition has been updated to show the new layout
- test_specs.py: some simple unit tests for specs
- semantic_model.py: 
&nbsp;&nbsp;- updates to 'Dimension' and 'Measure' Type definitions
&nbsp;&nbsp;- convert_measures and _convert_dimensions functions added
&nbsp;&nbsp;- parse_expressions updated
&nbsp;&nbsp;- json_definitions updated to include new objects in the json definition (dimension_descriptions and measure_descriptions)
&nbsp;&nbsp;- Ruff linting/formatting

Observations:

I have added the descriptions as new objects in the JSON, however i'm not sure if LLM's would better understand these if they were grouped with the dimension/measure, i.e:

```JSON
{
  "dimensions": [
    {
      "name": "Country",
      "description": "The country of the customer"
    }
  ],
  "measures": [
    {
      "name": "Total Sales",
      "description": "The total sales of the customer"
    }
  ]
}
```

instead of:

```JSON
{
  "dimensions": [
      "Country"
  ],
  "measures": [
      "Total Sales"
  ],
  "dimension_descriptions":
  {
    "country": "The country of the customer"
  },
  "measure_descriptions":
  {
    "total_sales": "The total sales of the customer"
  }
}
```