### PR TITLE
Fix column name collision issue in joins

### DIFF
--- a/src/boring_semantic_layer/query_compiler.py
+++ b/src/boring_semantic_layer/query_compiler.py
@@ -95,7 +95,7 @@ def _compile_query(qe: Any) -> Expr:
         if "." in m:
             alias, field = m.split(".", 1)
             join = model.joins[alias]
-            expr = join.model.measures[field](t)
+            expr = join.model.measures[field](join.model.table)
             name = f"{alias}_{field}"
             agg_kwargs[name] = expr
         else:
@@ -111,7 +111,8 @@ def _compile_query(qe: Any) -> Expr:
             if "." in d:
                 alias, field = d.split(".", 1)
                 name = f"{alias}_{field}"
-                expr = model.joins[alias].model.dimensions[field](t).name(name)
+                target_model = model.joins[alias].model
+                expr = target_model.dimensions[field](target_model.table).name(name)
             else:
                 # Use possibly transformed dimension function
                 expr = dim_map[d](t).name(d)

--- a/tests/test_malloy_style_joins.py
+++ b/tests/test_malloy_style_joins.py
@@ -46,6 +46,40 @@ def test_join_one_with_callable_foreign_key():
     )
     pd.testing.assert_frame_equal(result, expected)
 
+def test_join_aliasing():
+    # Test that joining two models with dimensions of the same names actually resolves correctly
+    products_df = pd.DataFrame({"category_id": [1, 2, 3], "name": ["P1", "P2", "P3"], "value": [1, 1, 1]})
+    categories_df = pd.DataFrame({"category_id": [1, 2, 3], "name": ["C1", "C2", "C3"], "value": [10, 10, 10]})
+    con = xo.connect()
+    products_tbl = con.create_table("products_tbl", products_df)
+    categories_tbl = con.create_table("categories_tbl", categories_df)
+
+    categories_model = SemanticModel(
+        table=categories_tbl,
+        primary_key="category_id",
+        dimensions={"category_id": lambda t: t.category_id, "name": lambda t: t.name},
+        measures={"sum_category_value": lambda t: t.value.sum()},
+    )
+
+    products_model = SemanticModel(
+        table=products_tbl,
+        joins={"category": Join.one("category", categories_model, with_=lambda t: t.category_id)},
+        dimensions={"category_id": lambda t: t.category_id, "name": lambda t: t.name},
+        measures={"sum_product_value": lambda t: t.value.sum()},
+    )
+
+    expr = products_model.query(dimensions=["name", "category.name"], measures=["sum_product_value", "category.sum_category_value"])
+    result = expr.execute().sort_values("name").reset_index(drop=True)
+    expected = pd.DataFrame(
+        {
+            "name": ["P1", "P2", "P3"],
+            "category_name": ["C1", "C2", "C3"],
+            "sum_product_value": [1, 1, 1],
+            "category_sum_category_value": [10, 10, 10],
+        }
+    )
+    pd.testing.assert_frame_equal(result, expected)
+
 
 def test_join_many_counts_children():
     # Departments with many employees


### PR DESCRIPTION
**Problem:** When joining tables with identical column names, dimension expressions would reference the wrong columns due to Ibis's automatic column renaming during joins.

**Root Cause:** Dimension and measure lambdas were being called on the final joined table where columns may be renamed, instead of the original table where column names are correct.

**Solution:** Modified query compiler to evaluate joined dimension/measure expressions on their original model tables rather than the final joined table.

See the included test case for a clear illustration for both dimensions and measures.