### PR TITLE
Relax Ibis req, and make the DuckDB extra optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ version = "0.1.8"
 description = "A boring semantic layer built with ibis"
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = ["attrs>=25.3.0", "ibis-framework[duckdb]>=10.6.0"]
+dependencies = ["attrs>=25.3.0", "ibis-framework"]
 urls = { Homepage = "https://github.com/boringdata/boring-semantic-layer/tree/main" }
 
 [project.optional-dependencies]
 mcp = ["mcp>=1.10.1"]
-examples = ["duckdb>=1.3.1", "xorq"]
+examples = ["ibis-framework[duckdb]>=10.6.0", "xorq"]
 xorq = ["xorq"]
 viz-altair = ["altair>=5.0.0"]
 viz-plotly = ["plotly>=6.3.0", "kaleido"]
@@ -26,4 +26,3 @@ dev = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-


### PR DESCRIPTION
When I installed the package, it automatically installed DuckDB for me, although I don't think it's necessary I use DuckDB. It seems it should only be needed for examples and tests.

I also don't know if there's a meaningful minimum Ibis version you're developing against; I unpinned it, but feel free to restrict it a bit. I don't think it needs to be `>=10.6.0` for users, though.