### PR TITLE
feat: add dict-based API for dimensions and measures with metadata

### DIFF
--- a/src/boring_semantic_layer/api/ops.py
+++ b/src/boring_semantic_layer/api/ops.py
@@ -74,20 +74,28 @@ def _classify_measure(fn_or_expr: Any, scope: Any):
     from .measure_nodes import MeasureRef, AllOf, BinOp
     from .measure_scope import ColumnScope
 
+    # Handle dict inputs by extracting expr and description
+    if isinstance(fn_or_expr, dict):
+        description = fn_or_expr.get("description")
+        fn_or_expr = fn_or_expr["expr"]
+    elif isinstance(fn_or_expr, Measure):
+        description = fn_or_expr.description
+        fn_or_expr = fn_or_expr.expr
+    else:
+        description = None
+
     val = _resolve_expr(fn_or_expr, scope)
     is_calc = isinstance(val, (MeasureRef, AllOf, BinOp, int, float))
 
     if is_calc:
         return ('calc', val)
-    elif isinstance(fn_or_expr, Measure):
-        return ('base', fn_or_expr)
     else:
         return ('base', Measure(
             expr=lambda t, fn=fn_or_expr: (
                 fn.resolve(ColumnScope(t)) if isinstance(fn, Deferred)
                 else fn(ColumnScope(t))
             ),
-            description=None
+            description=description
         ))
 
 


### PR DESCRIPTION
## Summary

This PR adds support for dict-based dimension and measure definitions with metadata, enabling richer semantic model documentation.

## Changes

### Core Implementation
- **Updated `_classify_measure()` helper** to handle dict inputs with `{"expr": ..., "description": ...}` format
- Dict API works automatically for both `SemanticTable.with_measures()` and `SemanticJoin.with_measures()`
- Preserves description metadata throughout the operation chain

### Testing
Added comprehensive test suite (`TestDictBasedMetadata`) with 7 tests covering:
- ✅ Dimension metadata storage
- ✅ Measure metadata storage  
- ✅ Mixed callable and dict API usage
- ✅ Metadata preservation through filter operations
- ✅ Metadata preservation through aggregate operations
- ✅ Metadata preservation through join operations
- ✅ Time dimension metadata support

All tests pass successfully.

## Example Usage

### Before (callable only):
\`\`\`python
st = to_semantic_table(tbl, "flights").with_dimensions(
    carrier=lambda t: t.carrier
).with_measures(
    flight_count=lambda t: t.count()
)
\`\`\`

### After (dict with metadata):
\`\`\`python
st = to_semantic_table(tbl, "flights").with_dimensions(
    carrier={
        "expr": lambda t: t.carrier,
        "description": "Airline carrier code"
    }
).with_measures(
    flight_count={
        "expr": lambda t: t.count(),
        "description": "Total number of flights"
    }
)
\`\`\`

## Benefits

1. **Self-documenting semantic models** - Descriptions provide context for dimensions and measures
2. **Backward compatible** - Existing callable-based API continues to work
3. **JSON export ready** - Metadata can be serialized via `json_definition` property
4. **IDE-friendly** - Dictionary format provides clear structure for metadata fields

## Test Plan

- [x] All existing tests pass
- [x] New dict-based metadata tests pass (7/7)
- [x] Mixed usage (callable + dict) works correctly
- [x] Metadata preserved through operations (filter, aggregate, join)

🤖 Generated with [Claude Code](https://claude.com/claude-code)