### PR TITLE
fix: add calc_measures property to SemanticJoinOp for consistent attribute naming

### DIFF
--- a/src/boring_semantic_layer/ops.py
+++ b/src/boring_semantic_layer/ops.py
@@ -1042,6 +1042,11 @@ class SemanticJoinOp(Relation):
         return dict(self.get_calculated_measures())
 
     @property
+    def calc_measures(self) -> dict[str, Any]:
+        """Get calculated measures as dict (for consistency with SemanticModel)."""
+        return dict(self.get_calculated_measures())
+
+    @property
     def measures(self) -> tuple[str, ...]:
         return tuple(self.get_measures().keys()) + tuple(
             self.get_calculated_measures().keys(),


### PR DESCRIPTION
## Summary

Fixes a bug where calling `repr()` on semantic operations involving joined tables would crash with `AttributeError: 'SemanticJoinOp' object has no attribute 'calc_measures'`.

## Problem

The formatting code in `format.py` expected all objects with `measures` to also have a `calc_measures` attribute. However, `SemanticJoinOp` only had `_calc_measures` (private) and `get_calculated_measures()` (method), but not the public `calc_measures` property that `SemanticModel` has.

This inconsistency caused crashes when:
- Displaying joined tables in Jupyter notebooks
- Calling `repr()` on group_by/aggregate operations on joined tables
- Pretty-printing semantic operations in interactive environments

## Solution

Added a `calc_measures` property to `SemanticJoinOp` to match the attribute naming convention used by `SemanticModel`, ensuring consistent access patterns across all semantic layer objects.

## Changes

- **src/boring_semantic_layer/ops.py**: Added `calc_measures` property to `SemanticJoinOp`
- **src/boring_semantic_layer/tests/test_join_prefixing.py**: Added test to verify repr() works correctly on joined tables

## Tests

```bash
pytest src/boring_semantic_layer/tests/test_join_prefixing.py::TestJoinOneMethod::test_join_one_repr_does_not_crash -v
```

✅ Test passes - repr() no longer crashes

## Related Issues

This PR also includes two additional tests that document a separate, unresolved bug where dimension access fails after `join_one()`:
- `test_join_one_with_dimension_access` 
- `test_join_one_with_multiple_dimensions_and_measures`

These tests currently fail with `AttributeError: 'Table' object has no attribute 'product_category'` and are left as documentation for future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)