### PR TITLE
fix: correct pytest path and remove test-release job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,45 +70,6 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
 
-  # Test release process (no environment protection, no actual publishing)
-  test-release:
-    name: Test Release
-    if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/bslv2') ||
-      (github.event_name == 'pull_request' && github.head_ref == 'bslv2')
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-
-      - name: Install dependencies
-        run: uv sync --all-extras
-
-      - name: Build package
-        run: uv build
-
-      - name: Test wheel installation
-        run: |
-          python -m venv test_env
-          test_env/bin/pip install dist/*.whl
-          test_env/bin/python -c "import boring_semantic_layer; print('✓ Successfully imported boring-semantic-layer')"
-
-      - name: Verify package contents
-        run: |
-          echo "Package contents:"
-          ls -lh dist/
-          echo "Wheel contents:"
-          unzip -l dist/*.whl | head -30
-
   # Release to PyPI (only on GitHub release)
   release-pypi:
     name: Release to PyPI
@@ -144,7 +105,7 @@ jobs:
           test_env/bin/python -c "import boring_semantic_layer; print('✓ Successfully imported boring-semantic-layer')"
 
       - name: Run tests with installed package
-        run: uv run pytest tests
+        run: uv run pytest
 
       - name: Publish to PyPI
         run: uv publish --trusted-publishing always


### PR DESCRIPTION
- Fix pytest path in release-pypi job: use auto-discovery instead of hardcoded 'tests' path
- Remove redundant test-release job that was specific to bslv2 branch

This fixes the release workflow failure where pytest couldn't find the tests directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)