### PR TITLE
Fix #98: Add with_dimensions() and with_measures() to SemanticFilter

### DIFF
--- a/src/boring_semantic_layer/expr.py
+++ b/src/boring_semantic_layer/expr.py
@@ -608,9 +608,58 @@ class SemanticFilter(SemanticTable):
     def schema(self):
         return self.op().schema
 
+    def get_dimensions(self):
+        return self.op().get_dimensions()
+
+    def get_measures(self):
+        return self.op().get_measures()
+
+    def get_calculated_measures(self):
+        return self.op().get_calculated_measures()
+
     def as_table(self) -> SemanticModel:
         all_roots = _find_all_root_models(self.op().source)
         return _build_semantic_model_from_roots(self.op().to_ibis(), all_roots)
+
+    def with_dimensions(self, **dims) -> SemanticModel:
+        """Add or update dimensions after filtering."""
+        all_roots = _find_all_root_models(self.op().source)
+        existing_dims = _get_merged_fields(all_roots, "dimensions") if all_roots else {}
+        existing_meas = _get_merged_fields(all_roots, "measures") if all_roots else {}
+        existing_calc = _get_merged_fields(all_roots, "calc_measures") if all_roots else {}
+
+        return SemanticModel(
+            table=self.op().to_ibis(),
+            dimensions={**existing_dims, **dims},
+            measures=existing_meas,
+            calc_measures=existing_calc,
+        )
+
+    def with_measures(self, **meas) -> SemanticModel:
+        """Add or update measures after filtering."""
+        all_roots = _find_all_root_models(self.op().source)
+        existing_dims = _get_merged_fields(all_roots, "dimensions") if all_roots else {}
+        existing_meas = _get_merged_fields(all_roots, "measures") if all_roots else {}
+        existing_calc = _get_merged_fields(all_roots, "calc_measures") if all_roots else {}
+
+        new_base_meas = dict(existing_meas)
+        new_calc_meas = dict(existing_calc)
+
+        all_measure_names = (
+            tuple(new_base_meas.keys()) + tuple(new_calc_meas.keys()) + tuple(meas.keys())
+        )
+        scope = MeasureScope(_tbl=self.op().to_ibis(), _known=all_measure_names)
+
+        for name, fn_or_expr in meas.items():
+            kind, value = _classify_measure(fn_or_expr, scope)
+            (new_calc_meas if kind == "calc" else new_base_meas)[name] = value
+
+        return SemanticModel(
+            table=self.op().to_ibis(),
+            dimensions=existing_dims,
+            measures=new_base_meas,
+            calc_measures=new_calc_meas,
+        )
 
 
 class SemanticGroupBy(SemanticTable):

--- a/src/boring_semantic_layer/tests/test_filter_with_dimensions.py
+++ b/src/boring_semantic_layer/tests/test_filter_with_dimensions.py
@@ -1,0 +1,125 @@
+"""Tests for issue #98: with_dimensions() after filter()."""
+import ibis
+import pandas as pd
+import pytest
+
+from boring_semantic_layer import to_semantic_table
+
+
+@pytest.fixture
+def con():
+    """Create an in-memory DuckDB connection."""
+    return ibis.duckdb.connect(":memory:")
+
+
+@pytest.fixture
+def flights(con):
+    """Create a sample flights table for testing."""
+    df = pd.DataFrame(
+        {
+            "carrier": ["AA", "AA", "DL", "DL", "UA"],
+            "origin": ["JFK", "LAX", "JFK", "ATL", "ORD"],
+            "destination": ["LAX", "JFK", "ATL", "JFK", "SFO"],
+            "arr_time": pd.to_datetime(
+                [
+                    "2023-01-15 10:30:00",
+                    "2023-01-16 14:20:00",
+                    "2023-02-10 09:15:00",
+                    "2023-02-11 18:45:00",
+                    "2023-03-05 12:00:00",
+                ]
+            ),
+            "distance": [2475, 2475, 748, 748, 1846],
+        }
+    )
+    return con.create_table("flights", df)
+
+
+def test_filter_then_with_dimensions(flights):
+    """Test that with_dimensions() works after filter()."""
+    # Create semantic model
+    semantic_flights = (
+        to_semantic_table(flights, "flights")
+        .with_dimensions(carrier=lambda t: t.carrier, origin=lambda t: t.origin)
+        .with_measures(flight_count=lambda t: t.count(), avg_distance=lambda t: t.distance.mean())
+    )
+
+    # Apply filter then with_dimensions - this should not raise AttributeError
+    result = (
+        semantic_flights.filter(lambda t: t.carrier == "AA")
+        .with_dimensions(arr_date=lambda t: t.arr_time.date())
+        .group_by("arr_date")
+        .aggregate("flight_count")
+    )
+
+    # Execute and verify
+    df = result.execute()
+    assert len(df) == 2  # Two different dates for AA flights
+    assert "arr_date" in df.columns
+    assert "flight_count" in df.columns
+
+
+def test_filter_then_with_measures(flights):
+    """Test that with_measures() also works after filter()."""
+    semantic_flights = (
+        to_semantic_table(flights, "flights")
+        .with_dimensions(carrier=lambda t: t.carrier)
+        .with_measures(flight_count=lambda t: t.count())
+    )
+
+    # Apply filter then with_measures
+    result = (
+        semantic_flights.filter(lambda t: t.carrier == "AA")
+        .with_measures(total_distance=lambda t: t.distance.sum())
+        .group_by("carrier")
+        .aggregate("flight_count", "total_distance")
+    )
+
+    # Execute and verify
+    df = result.execute()
+    assert len(df) == 1  # Only AA carrier
+    assert df["carrier"].iloc[0] == "AA"
+    assert "total_distance" in df.columns
+
+
+def test_filter_with_dimensions_preserves_existing(flights):
+    """Test that with_dimensions() preserves existing dimensions after filter()."""
+    semantic_flights = (
+        to_semantic_table(flights, "flights")
+        .with_dimensions(carrier=lambda t: t.carrier, origin=lambda t: t.origin)
+        .with_measures(flight_count=lambda t: t.count())
+    )
+
+    # Filter then add a new dimension
+    filtered = semantic_flights.filter(lambda t: t.carrier == "AA")
+    with_new_dim = filtered.with_dimensions(arr_date=lambda t: t.arr_time.date())
+
+    # Check that both old and new dimensions are available
+    dims = with_new_dim.get_dimensions()
+    assert "carrier" in dims
+    assert "origin" in dims
+    assert "arr_date" in dims
+
+
+def test_multiple_filters_with_dimensions(flights):
+    """Test chaining multiple operations including filter and with_dimensions."""
+    semantic_flights = (
+        to_semantic_table(flights, "flights")
+        .with_dimensions(carrier=lambda t: t.carrier)
+        .with_measures(flight_count=lambda t: t.count(), avg_distance=lambda t: t.distance.mean())
+    )
+
+    # Complex chaining
+    result = (
+        semantic_flights.filter(lambda t: t.distance > 1000)
+        .with_dimensions(month=lambda t: t.arr_time.month())
+        .filter(lambda t: t.carrier.isin(["AA", "UA"]))
+        .group_by("carrier", "month")
+        .aggregate("flight_count", "avg_distance")
+    )
+
+    # Execute and verify
+    df = result.execute()
+    assert len(df) > 0
+    assert "carrier" in df.columns
+    assert "month" in df.columns


### PR DESCRIPTION
## Summary
Fixes #98 by adding `with_dimensions()` and `with_measures()` methods to the `SemanticFilter` class, enabling flexible method chaining in the fluent API.

## Changes
- Added `with_dimensions()` method to `SemanticFilter` class
- Added `with_measures()` method to `SemanticFilter` class  
- Added helper methods: `get_dimensions()`, `get_measures()`, and `get_calculated_measures()`
- Created comprehensive test suite in `test_filter_with_dimensions.py`

## Test Coverage
The new test suite covers:
- ✅ Chaining `filter()` then `with_dimensions()`
- ✅ Chaining `filter()` then `with_measures()`
- ✅ Preservation of existing dimensions when adding new ones
- ✅ Complex multi-step chaining with multiple filters and dimensions

## Example Usage
\`\`\`python
result = (flights
    .filter(lambda t: t.carrier == 'AA')
    .with_dimensions(arr_date=lambda t: t.arr_time.date())
    .group_by('arr_date')
    .aggregate('flight_count'))
\`\`\`

This resolves the API composability issue where users previously encountered:
\`\`\`
AttributeError: 'SemanticFilter' object has no attribute 'with_dimensions'
\`\`\`

## Testing
All new tests pass, and no regressions were introduced to existing functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)