### PR TITLE
feat: add aggregate() method without group_by for single-row aggregations

### DIFF
--- a/src/boring_semantic_layer/expr.py
+++ b/src/boring_semantic_layer/expr.py
@@ -53,6 +53,21 @@ class SemanticTable(ir.Table):
     def group_by(self, *keys: str):
         return SemanticGroupBy(source=self.op(), keys=keys)
 
+    def aggregate(self, *measure_names, nest: dict[str, Callable] | None = None, **aliased):
+        """Aggregate measures without grouping (produces a single row result).
+
+        This is a convenience method that delegates to group_by().aggregate().
+
+        Args:
+            *measure_names: Measure names to aggregate
+            nest: Optional nested aggregations
+            **aliased: Optional aliased aggregations
+
+        Returns:
+            SemanticAggregate with no grouping keys
+        """
+        return self.group_by().aggregate(*measure_names, nest=nest, **aliased)
+
     def mutate(self, **post) -> SemanticMutate:
         return SemanticMutate(source=self.op(), post=post)
 


### PR DESCRIPTION
## Summary

Adds a convenience method to `SemanticTable` that allows calling `aggregate()` directly without first calling `group_by()`, which produces a single-row result with aggregated measures across all data.

## Changes

- Added `SemanticTable.aggregate()` method that delegates to `group_by().aggregate()`
- Added comprehensive tests for aggregate without group_by
- Added test for aggregate with single measure

## Motivation

This simplifies the API for common use cases where users want total aggregations across all data. Instead of requiring:

```python
flights.group_by().aggregate("flight_count")
```

Users can now write:

```python
flights.aggregate("flight_count")
```

## Test Plan

- ✅ Added `test_aggregate_without_group_by` - tests multi-measure aggregation
- ✅ Added `test_aggregate_with_single_measure` - tests single measure aggregation
- ✅ All tests passing
- ✅ Pre-commit hooks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)