### PR TITLE
feat: add xorq-based basic_flights example

### DIFF
--- a/examples/basic_flights_xorq.py
+++ b/examples/basic_flights_xorq.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Basic Semantic Table Usage with Flights using xorq tables."""
+
+import xorq.api as xo
+from ibis import _
+
+from boring_semantic_layer import to_semantic_table
+
+BASE_URL = "https://pub-a45a6a332b4646f2a6f44775695c64df.r2.dev"
+
+
+def main():
+    flights_tbl = xo.read_parquet(f"{BASE_URL}/flights.parquet")
+
+    flights = (
+        to_semantic_table(flights_tbl, name="flights")
+        .with_dimensions(
+            origin=lambda t: t.origin,
+            destination=lambda t: t.destination,
+            carrier=lambda t: t.carrier,
+            arr_time={
+                "expr": lambda t: t.arr_time,
+                "is_time_dimension": True,
+                "smallest_time_grain": "day",
+            },
+        )
+        .with_measures(
+            flight_count=lambda t: t.count(),
+            total_distance=lambda t: t.distance.sum(),
+            avg_distance=lambda t: t.distance.mean(),
+            max_distance=lambda t: t.distance.max(),
+            min_distance=lambda t: t.distance.min(),
+        )
+    )
+
+    result = flights.group_by("origin").aggregate("flight_count").limit(10).execute()
+    print("\nFlight counts by origin:")
+    print(result)
+
+    result = (
+        flights.group_by("origin", "carrier")
+        .aggregate("flight_count", "avg_distance")
+        .order_by(_.flight_count.desc())
+        .limit(10)
+        .execute()
+    )
+    print("\nFlights by origin and carrier:")
+    print(result)
+
+    flights_enhanced = flights.with_measures(
+        distance_per_flight=lambda t: t.distance.sum() / t.count(),
+    )
+
+    result = (
+        flights_enhanced.group_by("carrier")
+        .aggregate("flight_count", "total_distance", "distance_per_flight")
+        .order_by(_.distance_per_flight.desc())
+        .limit(10)
+        .execute()
+    )
+    print("\nDistance per flight by carrier:")
+    print(result)
+
+    long_haul_flights = flights_enhanced.filter(lambda t: t.distance > 1000)
+    result = (
+        long_haul_flights.group_by("carrier")
+        .aggregate("flight_count", "avg_distance")
+        .limit(10)
+        .execute()
+    )
+    print("\nLong-haul flights (>1000 miles):")
+    print(result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `basic_flights_xorq.py` example demonstrating semantic layer usage with xorq tables instead of ibis tables
- Uses `xo.read_parquet()` directly without needing a separate DuckDB connection

## Test plan
- [ ] Run `python examples/basic_flights_xorq.py` to verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)