### PR TITLE
feat: add filter support to YAML configuration

### DIFF
--- a/docs/md/doc/yaml-config.md
+++ b/docs/md/doc/yaml-config.md
@@ -101,6 +101,22 @@ result = (
 
 <bslquery code-block="query_yaml_model"></bslquery>
 
+## Filters
+
+You can apply a filter to all queries on a model by adding a `filter` field:
+
+```yaml
+flights:
+  table: flights_tbl
+  filter: _.year > 2020  # Applied to all queries
+  dimensions:
+    origin: _.origin
+  measures:
+    flight_count: _.count()
+```
+
+The filter expression uses the same `_` syntax as dimensions and measures. It's applied automatically when you query the model.
+
 ## Next Steps
 
 - See [Building Semantic Tables](/building/semantic-tables) for Python-based definitions

--- a/docs/md/doc/yaml_example.yaml
+++ b/docs/md/doc/yaml_example.yaml
@@ -1,5 +1,6 @@
 flights:
   table: flights_tbl
+  filter: _.year > 2020  # Optional: filter applied to all queries
   dimensions:
     origin:
       expr: _.origin


### PR DESCRIPTION
## Summary
- Add ability to define table-level filters in YAML semantic model definitions
- Filters use the same `_` expression syntax as dimensions and measures
- Filters are applied automatically to all queries on the model via `semantic_table.filter()`

## Example
```yaml
flights:
  table: flights_tbl
  filter: _.year > 2020  # Applied to all queries
  dimensions:
    origin: _.origin
  measures:
    flight_count: _.count()
```

## Test plan
- [x] Unit test for simple filter expression (`_.distance > 500`)
- [x] Unit test for complex filter expression (`_.origin.isin(['JFK', 'LAX'])`)
- [x] All 15 YAML tests pass
- [x] Documentation updated with filter usage example

🤖 Generated with [Claude Code](https://claude.com/claude-code)