### PR TITLE
fix: handle image paths for GitHub Pages and fail CI on example errors

### DIFF
--- a/docs/web/src/pages/BSLMarkdownPage.tsx
+++ b/docs/web/src/pages/BSLMarkdownPage.tsx
@@ -260,6 +260,21 @@ export default function BSLMarkdownPage({ pageSlug }: BSLMarkdownPageProps = {})
                   </a>
                 )
               },
+              // Images
+              img({ src, alt, ...props }) {
+                // Handle root-relative paths for GitHub Pages
+                const imageSrc = src?.startsWith('/')
+                  ? `${import.meta.env.BASE_URL}${src.slice(1)}`
+                  : src
+                return (
+                  <img
+                    src={imageSrc}
+                    alt={alt || ''}
+                    className="my-6 rounded-lg max-w-full"
+                    {...props}
+                  />
+                )
+              },
               // Tables
               table({ children }) {
                 return <Table className="my-6">{children}</Table>


### PR DESCRIPTION
## Summary
- Add `img` component to BSLMarkdownPage to prepend `BASE_URL` for root-relative image paths (fixes images not displaying on GitHub Pages)
- Change Makefile `check` target to use `&&` instead of `;` to fail fast on errors (CI now fails when examples fail)

## Test plan
- [ ] Verify images display correctly on deployed docs
- [ ] Verify CI fails when examples fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)