### PR TITLE
fix: lazy import langchain_anthropic for non-Anthropic models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boring-semantic-layer"
-version = "0.3.1"
+version = "0.3.2"
 description = "A boring semantic layer built with ibis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -157,7 +157,7 @@ wheels = [
 
 [[package]]
 name = "boring-semantic-layer"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary
- Lazy import `langchain_anthropic.middleware.AnthropicPromptCachingMiddleware` only when using Anthropic models
- Fixes: OpenAI-only users getting `No module named 'langchain_anthropic'` errors
- Bumps version to 0.3.2

## Test plan
- Run `bsl chat` with `--llm openai:gpt-4o` without `langchain-anthropic` installed
- Verify Anthropic models still work with prompt caching

🤖 Generated with [Claude Code](https://claude.com/claude-code)