### PR TITLE
Keep Altair as default chart backend

### DIFF
--- a/src/boring_semantic_layer/chart/__init__.py
+++ b/src/boring_semantic_layer/chart/__init__.py
@@ -2,8 +2,8 @@
 Chart functionality for semantic API.
 
 Provides multiple backends for visualization:
-- ECharts: Apache ECharts based declarative charts (default)
-- Altair: Vega-Lite based declarative charts
+- Altair: Vega-Lite based declarative charts (default)
+- ECharts: Apache ECharts based declarative charts
 - Plotly: Interactive web-based charts
 - Plotext: Terminal-based charts
 
@@ -62,7 +62,7 @@ def list_backends() -> list[str]:
 def chart(
     semantic_aggregate: Any,
     spec: dict[str, Any] | None = None,
-    backend: str = "echarts",
+    backend: str = "altair",
     format: str = "static",
 ) -> Any:
     """
@@ -73,21 +73,21 @@ def chart(
         spec: Optional chart specification dict (backend-specific format).
               If partial spec is provided (e.g., only "mark" or only "encoding"),
               missing parts will be auto-detected and merged.
-        backend: Visualization backend ("echarts", "altair", "plotly", or "plotext")
-                 Default is "echarts".
+        backend: Visualization backend ("altair", "echarts", "plotly", or "plotext")
+                 Default is "altair".
         format: Output format (backend-specific, typically "static", "interactive", "json")
 
     Returns:
         Chart object or formatted output (type depends on backend and format)
 
     Examples:
-        # Auto-detect chart type with ECharts (default)
+        # Auto-detect chart type with Altair (default)
         result = flights.group_by("carrier").aggregate("flight_count")
         chart(result)
 
-        # Use Altair backend
+        # Use ECharts backend
         result = flights.group_by("dep_month").aggregate("flight_count")
-        chart(result, backend="altair")
+        chart(result, backend="echarts")
 
         # Use Plotly backend
         result = flights.group_by("dep_month").aggregate("flight_count")

--- a/src/boring_semantic_layer/chart/tests/test_echarts.py
+++ b/src/boring_semantic_layer/chart/tests/test_echarts.py
@@ -62,16 +62,6 @@ class TestEChartsBackendRegistration:
         backends = list_backends()
         assert "echarts" in backends
 
-    def test_echarts_is_default_backend(self, flights_model):
-        """Test that ECharts is the default backend."""
-        result = flights_model.group_by("carrier").aggregate("flight_count")
-        # Call chart() without specifying backend
-        chart = result.chart()
-
-        # Should be a dict (ECharts spec)
-        assert isinstance(chart, dict)
-        # ECharts specs have series
-        assert "series" in chart
 
 
 class TestEChartsBasicCharts:


### PR DESCRIPTION
ECharts is available but Altair remains the default for backward compatibility.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>