### PR TITLE
chore: bump version to 0.3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boring-semantic-layer"
-version = "0.3.5"
+version = "0.3.6"
 description = "A boring semantic layer built with ibis"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Release v0.3.6

Changes:
- feat: ECharts chart backend
- Keep Altair as default backend