### PR TITLE
fix: unwrap nested chart spec in dashboard renderer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boring-semantic-layer"
-version = "0.3.7"
+version = "0.3.8"
 description = "A boring semantic layer built with ibis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/boring_semantic_layer/chart/md_parser/dashboard.py
+++ b/src/boring_semantic_layer/chart/md_parser/dashboard.py
@@ -529,6 +529,9 @@ def _render_component(comp: dict) -> str:
 
 def _render_vega_chart(spec: dict) -> str:
     """Render a Vega-Lite chart."""
+    # Unwrap nested spec if present (converter returns {"type": "vega", "spec": {...}})
+    if "spec" in spec and isinstance(spec.get("spec"), dict):
+        spec = spec["spec"]
     chart_id = f"chart_{abs(hash(json.dumps(spec, cls=CustomJSONEncoder))) % 100000}"
     chart_json = json.dumps(spec, cls=CustomJSONEncoder)
 


### PR DESCRIPTION
## Summary
- Fix chart rendering in dashboards by unwrapping nested Vega spec
- The converter returns `{"type": "vega", "spec": {...}}` but vegaEmbed expects the spec directly
- Bump version to 0.3.8

## Problem
Charts were not rendering in dashboards. The `_render_vega_chart` function was passing the wrapped spec to vegaEmbed:
```javascript
vegaEmbed("#chart_123", {"type": "vega", "spec": {...}}, {...})
```

But vegaEmbed expects:
```javascript
vegaEmbed("#chart_123", {...}, {...})
```

## Solution
Unwrap the nested spec if the "spec" key is present:
```python
if "spec" in spec and isinstance(spec.get("spec"), dict):
    spec = spec["spec"]
```

## Test plan
- [x] Tested with themed dashboard containing bar charts and heatmaps
- [x] Charts now render correctly with editorial theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)