### PR TITLE
feat: support filtering by measures in query()

### DIFF
--- a/src/boring_semantic_layer/expr.py
+++ b/src/boring_semantic_layer/expr.py
@@ -587,6 +587,7 @@ class SemanticModel(SemanticTable):
         limit: int | None = None,
         time_grain: str | None = None,
         time_range: dict[str, str] | None = None,
+        having: list | None = None,
     ):
         return build_query(
             semantic_table=self,
@@ -597,6 +598,7 @@ class SemanticModel(SemanticTable):
             limit=limit,
             time_grain=time_grain,
             time_range=time_range,
+            having=having,
         )
 
 
@@ -744,6 +746,7 @@ class SemanticJoin(SemanticTable):
         limit: int | None = None,
         time_grain: str | None = None,
         time_range: dict[str, str] | None = None,
+        having: list | None = None,
     ):
         return build_query(
             semantic_table=self,
@@ -754,6 +757,7 @@ class SemanticJoin(SemanticTable):
             limit=limit,
             time_grain=time_grain,
             time_range=time_range,
+            having=having,
         )
 
     def as_table(self) -> SemanticModel:

--- a/src/boring_semantic_layer/ops.py
+++ b/src/boring_semantic_layer/ops.py
@@ -2603,6 +2603,7 @@ class SemanticJoinOp(Relation):
         limit: int | None = None,
         time_grain: str | None = None,
         time_range: dict[str, str] | None = None,
+        having: list | None = None,
     ):
         from .query import query as build_query
 
@@ -2615,6 +2616,7 @@ class SemanticJoinOp(Relation):
             limit=limit,
             time_grain=time_grain,
             time_range=time_range,
+            having=having,
         )
 
     def with_dimensions(self, **dims) -> SemanticTable:


### PR DESCRIPTION
## Summary
Fixes #177

Measure-based filters in `query()` are now automatically detected and applied **after aggregation** (HAVING semantics) instead of before (WHERE). This enables common analytical patterns like:

```python
st.query(
    dimensions=["store_name"],
    measures=["metric_ventas_brutas_con_iva"],
    filters=[{"field": "metric_ventas_brutas_con_iva", "operator": "is not null"}],
    order_by=[("metric_ventas_brutas_con_iva", "desc")]
)
```

### How it works
- Dict and `Filter` object filters are classified as measure vs dimension based on field names
- Dimension filters apply pre-aggregation (WHERE) as before
- Measure filters apply post-aggregation (HAVING semantics)
- Handles model-prefixed names (`model.measure`), compound filters (AND/OR), and joined models with dotted column names
- Field names are normalized against known measures so prefixed names resolve correctly on both standalone and joined models

## Test plan
- [x] 6 new tests in `TestMeasureFilters` covering:
  - Measure filter with `>` operator
  - Measure filter with `is not null`
  - Mixed dimension + measure filters
  - Model-prefixed measure filter names
  - Compound (AND) measure filters
  - Dimension filters still apply pre-aggregation
- [x] All 629 existing tests pass
- [x] Codex CLI review: addressed both P1 (dotted names) and P2 (Filter objects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)