### PR TITLE
fix: strip VARCHAR(N) length from dtype strings in _make_schema

### DIFF
--- a/src/boring_semantic_layer/ops.py
+++ b/src/boring_semantic_layer/ops.py
@@ -342,8 +342,14 @@ def _semantic_repr(op: Relation) -> str:
 
 
 def _make_schema(fields_dict: dict[str, str]):
-    """Create Schema instance from fields dict."""
-    return _SchemaClass(fields_dict)
+    """Create Schema instance from fields dict.
+
+    Strips length parameters from string types (e.g. ``string(50)`` → ``string``)
+    so that backends like Postgres whose ``VARCHAR(N)`` serialises as ``string(N)``
+    can be parsed by the Schema constructor.
+    """
+    cleaned = {k: re.sub(r"\bstring\(\d+\)", "string", v) for k, v in fields_dict.items()}
+    return _SchemaClass(cleaned)
 
 
 def _resolve_expr(expr: Deferred | Callable | Any, scope: ir.Table) -> ir.Value:

--- a/src/boring_semantic_layer/tests/test_make_schema.py
+++ b/src/boring_semantic_layer/tests/test_make_schema.py
@@ -1,0 +1,39 @@
+"""Tests for _make_schema, especially Postgres VARCHAR(N) handling."""
+
+from __future__ import annotations
+
+from boring_semantic_layer.ops import _make_schema
+
+
+def test_make_schema_plain_types():
+    schema = _make_schema({"a": "string", "b": "int32"})
+    assert "a" in schema
+    assert "b" in schema
+
+
+def test_make_schema_postgres_varchar():
+    """Postgres VARCHAR(50) serialises as '!string(50)'; Schema must accept it."""
+    schema = _make_schema({"col_a": "!string(50)", "col_b": "!int32"})
+    assert "col_a" in schema
+    assert "col_b" in schema
+
+
+def test_make_schema_mixed_postgres_types():
+    """Realistic Postgres join schema with VARCHAR, DECIMAL, and plain types."""
+    schema = _make_schema({
+        "snapshot_date": "!date",
+        "balance": "!decimal(15, 2)",
+        "bank_id": "string",
+        "bank_name": "!string(50)",
+        "bank": "!string(50)",
+    })
+    assert set(schema.names) == {"snapshot_date", "balance", "bank_id", "bank_name", "bank"}
+    # decimal(15, 2) must be preserved
+    assert "decimal" in str(schema["balance"])
+
+
+def test_make_schema_string_without_length_unchanged():
+    """Plain 'string' type must not be mangled by the regex."""
+    schema = _make_schema({"a": "string", "b": "!string"})
+    assert "a" in schema
+    assert "b" in schema


### PR DESCRIPTION
## Summary
- Strips `string(N)` length parameters in `_make_schema` so Postgres `VARCHAR(N)` columns don't crash the Schema constructor when resolving joins
- Adds targeted tests for plain, nullable, and mixed Postgres dtype strings

Closes #183

## Test plan
- [x] `test_make_schema_postgres_varchar` — exact repro from the issue (`!string(50)`)
- [x] `test_make_schema_mixed_postgres_types` — realistic join schema with VARCHAR + DECIMAL
- [x] `test_make_schema_plain_types` / `test_make_schema_string_without_length_unchanged` — no regression on normal string types

🤖 Generated with [Claude Code](https://claude.com/claude-code)