### PR TITLE
fix: support multi-level derived dimensions in filters

### DIFF
--- a/src/boring_semantic_layer/ops.py
+++ b/src/boring_semantic_layer/ops.py
@@ -1046,10 +1046,23 @@ class SemanticFilterOp(Relation):
             else _get_merged_fields(all_roots, "dimensions")
         )
 
+        # Enrich table with derived dimensions so multi-level deps
+        # (e.g. d_two -> d_one -> distance) resolve correctly in filters.
+        # Best-effort: skip dimensions whose columns aren't available yet
+        # (e.g. join-based dims); those resolve through the Resolver fallback.
+        enriched = base_tbl
+        for dim_name in dim_map:
+            try:
+                enriched = _mutate_dimensions_with_dependencies(
+                    enriched, [dim_name], dim_map
+                )
+            except (TypeError, KeyError, AttributeError):
+                pass
+
         pred_fn = _unwrap(self.predicate)
-        resolver = _Resolver(base_tbl, dim_map)
+        resolver = _Resolver(enriched, dim_map)
         pred = _resolve_expr(pred_fn, resolver)
-        return base_tbl.filter(pred)
+        return enriched.filter(pred)
 
     def get_dimensions(self) -> Mapping[str, Dimension]:
         """Get dictionary of dimensions from source."""

--- a/src/boring_semantic_layer/tests/test_query.py
+++ b/src/boring_semantic_layer/tests/test_query.py
@@ -266,6 +266,95 @@ class TestMultiLayerDerivedFields:
         assert "total_flights" in sql_two
 
 
+class TestMultiLevelDimensionFilters:
+    """Test filtering on multi-level derived dimensions (#182)."""
+
+    @pytest.fixture()
+    def flights_st(self):
+        tbl = ibis.memtable({
+            "origin": ["NYC", "LAX", "NYC", "SFO", "LAX"],
+            "distance": [2789, 2789, 2902, 347, 347],
+            "duration": [330, 330, 360, 65, 65],
+        })
+        return (
+            to_semantic_table(tbl, name="flights")
+            .with_dimensions(
+                origin=lambda t: t.origin,
+                distance=lambda t: t.distance,
+                d_one=lambda t: t.distance.add(1),
+                d_two=lambda t: t.d_one.add(1),
+            )
+            .with_measures(
+                avg_duration=lambda t: t.duration.mean(),
+            )
+        )
+
+    def test_filter_lambda_on_second_level_derived(self, flights_st):
+        result = flights_st.filter(ibis._.d_two > 1000).execute()
+        assert len(result) > 0
+        assert all(result["d_two"] > 1000)
+
+    def test_query_dict_filter_on_second_level_derived(self, flights_st):
+        result = flights_st.query(
+            dimensions=["d_two"],
+            measures=["avg_duration"],
+            filters=[{"field": "d_two", "operator": ">", "value": 1000}],
+        ).execute()
+        assert len(result) > 0
+        assert all(result["d_two"] > 1000)
+
+    def test_query_deferred_filter_on_second_level_derived(self, flights_st):
+        result = flights_st.query(
+            dimensions=["d_two"],
+            filters=[ibis._.d_two > 1000],
+        ).execute()
+        assert len(result) > 0
+
+    def test_filter_on_first_level_derived_still_works(self, flights_st):
+        result = flights_st.filter(ibis._.d_one > 1000).execute()
+        assert len(result) > 0
+        assert all(result["d_one"] > 1000)
+
+    def test_chained_filters_on_derived_dims(self, flights_st):
+        """Stacked filter().filter() both referencing derived dimensions."""
+        result = (
+            flights_st
+            .filter(ibis._.d_one > 500)
+            .filter(ibis._.d_two > 1000)
+            .execute()
+        )
+        assert len(result) > 0
+        assert all(result["d_one"] > 500)
+        assert all(result["d_two"] > 1000)
+
+    def test_three_level_derived_dimension_filter(self):
+        """Arbitrary-depth chain: d_three -> d_two -> d_one -> distance."""
+        tbl = ibis.memtable({
+            "distance": [2789, 347, 2902],
+        })
+        st = (
+            to_semantic_table(tbl, name="test")
+            .with_dimensions(
+                d_one=lambda t: t.distance.add(1),
+                d_two=lambda t: t.d_one.add(1),
+                d_three=lambda t: t.d_two.add(1),
+            )
+        )
+        result = st.filter(ibis._.d_three > 1000).execute()
+        assert len(result) > 0
+        assert all(result["d_three"] > 1000)
+
+    def test_filter_derived_dim_not_in_query_dimensions(self, flights_st):
+        """Filter on a derived dim that is not in the requested dimensions."""
+        result = flights_st.query(
+            dimensions=["origin"],
+            measures=["avg_duration"],
+            filters=[ibis._.d_two > 1000],
+        ).execute()
+        assert len(result) > 0
+        assert "origin" in result.columns
+
+
 class TestFilters:
     """Test filter functionality."""
 


### PR DESCRIPTION
## Summary
- Enriches the base table with derived dimensions (best-effort) in `SemanticFilterOp.to_untagged()` so that multi-level chains like `d_two -> d_one -> distance` resolve correctly in filter predicates
- Dimensions from joined tables that can't be materialized pre-join are silently skipped and resolve through the existing `_Resolver` fallback
- Uses the same `_mutate_dimensions_with_dependencies` function already used in `SemanticAggregateOp.to_untagged()`

Closes #182

## Test plan
- [x] `test_filter_lambda_on_second_level_derived` — `filter(_.d_two > 1000)` (was crashing)
- [x] `test_query_dict_filter_on_second_level_derived` — dict filter `{'field': 'd_two', ...}` (was crashing)
- [x] `test_query_deferred_filter_on_second_level_derived` — deferred `ibis._.d_two > 1000` (was crashing)
- [x] `test_chained_filters_on_derived_dims` — stacked `filter().filter()` on derived dims
- [x] `test_three_level_derived_dimension_filter` — 3-level chain `d_three -> d_two -> d_one`
- [x] `test_filter_derived_dim_not_in_query_dimensions` — filter dim not in requested dims
- [x] `test_filter_on_first_level_derived_still_works` — regression check
- [x] All 89 existing filter/dimension/join tests pass (0 regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)