### PR TITLE
fix: resolve unprefixed measure names via suffix matching on joined models

### DIFF
--- a/src/boring_semantic_layer/measure_scope.py
+++ b/src/boring_semantic_layer/measure_scope.py
@@ -209,6 +209,11 @@ def _resolve_measure_name(
 ) -> Maybe[str]:
     if name in known_set:
         return Some(name)
+    # Suffix matching: resolve unprefixed name to prefixed equivalent
+    suffix = f".{name}"
+    matches = tuple(k for k in known if k.endswith(suffix))
+    if len(matches) == 1:
+        return Some(matches[0])
     return Maybe.from_optional(None)
 
 


### PR DESCRIPTION
## Summary
- After `join_many`, measures get prefixed (e.g. `flights.flight_count`)
- Adds `_resolve_measure_name` to do suffix matching so unprefixed lookups still work

## Test plan
- [ ] `test_join_prefixing.py` tests pass
- [ ] Verify both prefixed and unprefixed measure names resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)