### PR TITLE
fix: replace _parse_field with _parse_structured_dict to preserve resolver tuples

### DIFF
--- a/src/boring_semantic_layer/tests/test_xorq_string_serialization.py
+++ b/src/boring_semantic_layer/tests/test_xorq_string_serialization.py
@@ -1621,10 +1621,11 @@ def test_tagged_roundtrip_join_many_without_with_dimensions():
 def test_tagged_roundtrip_join_derived_dimension_on_root():
     """Derived dimension on root table survives to_tagged → from_tagged round-trip.
 
-    Regression: _parse_field's _tuple_to_mutable mangled expr_struct resolver
-    tuples (e.g. converting empty () to {}, collapsing tuple-of-pairs into
-    dicts), causing _create_dimension to fall through to a literal column
-    lookup that fails with XorqTypeError.
+    Regression: the old _parse_field helper recursively mangled expr_struct
+    resolver tuples (e.g. converting empty () to {}, collapsing tuple-of-pairs
+    into dicts), causing _create_dimension to fall through to a literal column
+    lookup that fails with XorqTypeError.  Fixed by replacing _parse_field
+    with _parse_structured_dict (one-level-only conversion).
     """
     import pandas as pd
 

--- a/src/boring_semantic_layer/utils.py
+++ b/src/boring_semantic_layer/utils.py
@@ -296,6 +296,7 @@ def serialize_resolver(resolver) -> tuple:
         Attr,
         BinaryOperator,
         Call,
+        Item,
         Just,
         JustUnhashable,
         Mapping as MappingResolver,
@@ -334,6 +335,9 @@ def serialize_resolver(resolver) -> tuple:
 
     if isinstance(resolver, Attr):
         return ("attr", serialize_resolver(resolver.obj), serialize_resolver(resolver.name))
+
+    if isinstance(resolver, Item):
+        return ("item", serialize_resolver(resolver.obj), serialize_resolver(resolver.name))
 
     if isinstance(resolver, Call):
         func_tuple = serialize_resolver(resolver.func)
@@ -406,6 +410,7 @@ def deserialize_resolver(data: tuple):
         Attr,
         BinaryOperator,
         Call,
+        Item,
         Just,
         Mapping as MappingResolver,
         Sequence,
@@ -437,6 +442,14 @@ def deserialize_resolver(data: tuple):
             object.__setattr__(attr, "obj", obj_resolver)
             object.__setattr__(attr, "name", name_resolver)
             return attr
+
+        case ("item", obj_data, name_data):
+            obj_resolver = deserialize_resolver(obj_data)
+            name_resolver = deserialize_resolver(name_data)
+            item = object.__new__(Item)
+            object.__setattr__(item, "obj", obj_resolver)
+            object.__setattr__(item, "name", name_resolver)
+            return item
 
         case ("call", func_data, args_data, kwargs_data):
             func_resolver = deserialize_resolver(func_data)

--- a/src/boring_semantic_layer/xorq_convert.py
+++ b/src/boring_semantic_layer/xorq_convert.py
@@ -499,35 +499,12 @@ def from_tagged(tagged_expr):
 # ---------------------------------------------------------------------------
 
 
-def _parse_field(metadata: dict, field: str) -> dict | list:
-    """Extract a field from tag metadata, converting frozen tuples back to mutable types.
-
-    xorq's FrozenOrderedDict stores dicts as tuples-of-pairs and lists as tuples.
-    This function reverses that transformation so reconstructors see plain dicts/lists.
-    """
-    value = metadata.get(field)
-    if not value:
-        return {} if field != "order_keys" else []
-
-    def _tuple_to_mutable(obj):
-        if isinstance(obj, tuple):
-            if len(obj) == 0:
-                return {}
-            if all(
-                isinstance(item, tuple) and len(item) == 2 and isinstance(item[0], str)
-                for item in obj
-            ):
-                return {k: _tuple_to_mutable(v) for k, v in obj}
-            else:
-                return [_tuple_to_mutable(item) for item in obj]
-        else:
-            return obj
-
-    return _tuple_to_mutable(value)
-
-
 def _list_to_tuple(obj):
-    """Recursively convert lists back to tuples (reverses _tuple_to_mutable for expr_struct)."""
+    """Recursively convert lists/dicts back to nested tuples.
+
+    Used as a safety net for v1.0 backward-compat paths where data may have
+    been stored via the old ``_tuple_to_mutable`` (removed) round-trip.
+    """
     if isinstance(obj, list):
         return tuple(_list_to_tuple(item) for item in obj)
     if isinstance(obj, dict):
@@ -538,8 +515,8 @@ def _list_to_tuple(obj):
 def _parse_structured_dict(raw) -> dict:
     """Convert a FrozenOrderedDict-encoded tuple-of-pairs to a dict (one level only).
 
-    Unlike ``_tuple_to_mutable``, this does NOT recurse into values.
-    Resolver tuples stored as values are returned untouched.
+    Does NOT recurse into values — resolver tuples stored as values are
+    returned untouched, which is critical for correct deserialization.
     """
     match raw:
         case dict():


### PR DESCRIPTION
## Summary
- Replaces `_parse_field` with `_parse_structured_dict` to preserve resolver tuples (avoids FrozenOrderedDict mangling)
- Adds `Item` resolver serialization support
- Removes dead `_parse_field` code

**Depends on:** #189

## Test plan
- [ ] Structured dict parsing preserves nested resolver tuples
- [ ] `test_xorq_string_serialization.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)