### PR TITLE
fix: resolve ambiguous field reference in multi-way joins with shared column names

### DIFF
--- a/src/boring_semantic_layer/tests/test_xorq_string_serialization.py
+++ b/src/boring_semantic_layer/tests/test_xorq_string_serialization.py
@@ -1616,3 +1616,202 @@ def test_tagged_roundtrip_join_many_without_with_dimensions():
     assert got_hc["Sales"] == 1
     assert got_sal["Engineering"] == 110000
     assert got_sal["Sales"] == 70000
+
+
+def test_tagged_roundtrip_join_derived_dimension_on_root():
+    """Derived dimension on root table survives to_tagged → from_tagged round-trip.
+
+    Regression: the old _parse_field helper recursively mangled expr_struct
+    resolver tuples (e.g. converting empty () to {}, collapsing tuple-of-pairs
+    into dicts), causing _create_dimension to fall through to a literal column
+    lookup that fails with XorqTypeError.  Fixed by replacing _parse_field
+    with _parse_structured_dict (one-level-only conversion).
+    """
+    import pandas as pd
+
+    from boring_semantic_layer import Dimension, Measure
+    from boring_semantic_layer.xorq_convert import from_tagged, to_tagged
+
+    con = ibis.duckdb.connect(":memory:")
+    flights = pd.DataFrame(
+        {
+            "origin": ["SEA", "SEA", "LAX", "LAX", "ORD"],
+            "dep_time": pd.to_datetime(
+                ["2024-01-01 08:00", "2024-01-01 14:00", "2024-01-01 08:00", "2024-01-01 20:00", "2024-01-01 14:00"]
+            ),
+            "carrier": ["AA", "UA", "AA", "DL", "UA"],
+        }
+    )
+    carriers = pd.DataFrame(
+        {
+            "code": ["AA", "UA", "DL"],
+            "nickname": ["American", "United", "Delta"],
+        }
+    )
+    f_tbl = con.create_table("flights_dd", flights)
+    c_tbl = con.create_table("carriers_dd", carriers)
+
+    flights_st = (
+        to_semantic_table(f_tbl, name="flights_dd")
+        .with_dimensions(
+            origin=Dimension(expr=lambda t: t.origin, description="Origin"),
+            dep_hour=Dimension(expr=lambda t: t.dep_time.hour(), description="Departure hour"),
+        )
+        .with_measures(
+            flight_count=Measure(expr=lambda t: t.count(), description="Count"),
+        )
+    )
+    carriers_st = (
+        to_semantic_table(c_tbl, name="carriers_dd")
+        .with_dimensions(
+            code=Dimension(expr=lambda t: t.code, description="Code"),
+            nickname=Dimension(expr=lambda t: t.nickname, description="Nickname"),
+        )
+        .with_measures(
+            carrier_count=Measure(expr=lambda t: t.count(), description="Count"),
+        )
+    )
+
+    joined = flights_st.join_one(carriers_st, on=lambda f, c: f.carrier == c.code)
+
+    # Baseline: group by the derived dimension before round-trip
+    baseline = (
+        joined
+        .group_by("flights_dd.dep_hour")
+        .aggregate("flights_dd.flight_count")
+        .order_by("flights_dd.dep_hour")
+        .execute()
+    )
+
+    # Round-trip
+    tagged = to_tagged(joined)
+    reconstructed = from_tagged(tagged)
+
+    result = (
+        reconstructed
+        .group_by("flights_dd.dep_hour")
+        .aggregate("flights_dd.flight_count")
+        .order_by("flights_dd.dep_hour")
+        .execute()
+    )
+
+    assert len(result) == len(baseline)
+    assert list(result["flights_dd.dep_hour"]) == list(baseline["flights_dd.dep_hour"])
+    assert list(result["flights_dd.flight_count"]) == list(baseline["flights_dd.flight_count"])
+
+
+@pytest.mark.parametrize(
+    "n_joins",
+    [2, 3, 4],
+    ids=["2_joins", "3_joins", "4_joins"],
+)
+def test_tagged_roundtrip_join_chain_shared_column_names(n_joins):
+    """Multi-way join_one chain with shared column names survives round-trip.
+
+    Regression: when 3+ dimension tables share a column name (e.g. "code"),
+    ibis's default ``{name}_right`` suffix collided on the third table,
+    raising ``IntegrityError: Name collisions``.  After ``to_tagged →
+    from_tagged``, the same collision caused ``Ambiguous field reference``.
+
+    Fixed by:
+    - depth-based ``rname`` in ``SemanticJoinOp.to_untagged`` (``_right``,
+      ``_right2``, ``_right3``, …)
+    - matching suffix in ``_check_and_add_rename``
+    - preserving ``SelfReference`` (view) aliasing in ``_reconstruct_table``
+    - intersection-only join-key detection in ``_extract_join_key_column_names``
+    """
+    import pandas as pd
+
+    from xorq.common.utils.ibis_utils import from_ibis
+
+    from boring_semantic_layer import Dimension, Measure
+    from boring_semantic_layer.xorq_convert import from_tagged, to_tagged
+
+    con = ibis.duckdb.connect(":memory:")
+
+    flights_df = pd.DataFrame({
+        "carrier": ["AA", "UA", "AA", "DL", "UA"],
+        "origin": ["SEA", "LAX", "ORD", "SEA", "LAX"],
+        "destination": ["LAX", "ORD", "SEA", "ORD", "SEA"],
+        "tail_num": ["N101", "N102", "N103", "N101", "N102"],
+    })
+    carriers_df = pd.DataFrame({
+        "code": ["AA", "UA", "DL"],
+        "nickname": ["American", "United", "Delta"],
+    })
+    airports_df = pd.DataFrame({
+        "code": ["SEA", "LAX", "ORD"],
+        "city": ["Seattle", "Los Angeles", "Chicago"],
+    })
+    aircraft_df = pd.DataFrame({
+        "tail_num": ["N101", "N102", "N103"],
+        "year_built": [2010, 2015, 2020],
+    })
+
+    f_tbl = from_ibis(con.create_table(f"fl_{n_joins}", flights_df))
+    c_tbl = from_ibis(con.create_table(f"ca_{n_joins}", carriers_df))
+    # Single airports table with .view() for origin/dest — matches the
+    # deferred_read_parquet + .view() pattern from the original repro.
+    # SelfReference gives each view a distinct ibis identity.
+    a_tbl = from_ibis(con.create_table(f"ap_{n_joins}", airports_df))
+    ac_tbl = from_ibis(con.create_table(f"ac_{n_joins}", aircraft_df))
+
+    flights_st = (
+        to_semantic_table(f_tbl, name="flights")
+        .with_dimensions(
+            carrier=Dimension(expr=lambda t: t.carrier),
+            origin=Dimension(expr=lambda t: t.origin),
+            destination=Dimension(expr=lambda t: t.destination),
+            tail_num=Dimension(expr=lambda t: t.tail_num),
+        )
+        .with_measures(flight_count=Measure(expr=lambda t: t.count()))
+    )
+    carriers_st = to_semantic_table(c_tbl, name="carriers").with_dimensions(
+        code=Dimension(expr=lambda t: t.code),
+        nickname=Dimension(expr=lambda t: t.nickname),
+    )
+    origin_st = to_semantic_table(a_tbl.view(), name="origin_airports").with_dimensions(
+        code=Dimension(expr=lambda t: t.code),
+        city=Dimension(expr=lambda t: t.city),
+    )
+    dest_st = to_semantic_table(a_tbl.view(), name="dest_airports").with_dimensions(
+        code=Dimension(expr=lambda t: t.code),
+        city=Dimension(expr=lambda t: t.city),
+    )
+    aircraft_st = to_semantic_table(ac_tbl, name="aircraft").with_dimensions(
+        tail_num=Dimension(expr=lambda t: t.tail_num),
+        year_built=Dimension(expr=lambda t: t.year_built),
+    )
+
+    # Build chain: n_joins = number of join_one calls
+    joined = flights_st.join_one(carriers_st, lambda f, c: f.carrier == c.code)
+    if n_joins >= 2:
+        joined = joined.join_one(origin_st, lambda f, o: f.origin == o.code)
+    if n_joins >= 3:
+        joined = joined.join_one(dest_st, lambda f, d: f.destination == d.code)
+    if n_joins >= 4:
+        joined = joined.join_one(aircraft_st, lambda f, a: f.tail_num == a.tail_num)
+
+    # In-process baseline
+    baseline = (
+        joined
+        .group_by("carriers.nickname")
+        .aggregate("flights.flight_count")
+        .order_by("carriers.nickname")
+        .execute()
+    )
+
+    # Round-trip
+    tagged = to_tagged(joined)
+    reconstructed = from_tagged(tagged)
+    result = (
+        reconstructed
+        .group_by("carriers.nickname")
+        .aggregate("flights.flight_count")
+        .order_by("carriers.nickname")
+        .execute()
+    )
+
+    assert len(result) == len(baseline)
+    assert list(result["carriers.nickname"]) == list(baseline["carriers.nickname"])
+    assert list(result["flights.flight_count"]) == list(baseline["flights.flight_count"])

--- a/src/boring_semantic_layer/xorq_convert.py
+++ b/src/boring_semantic_layer/xorq_convert.py
@@ -684,6 +684,10 @@ def _reconstruct_semantic_table(metadata: dict, xorq_expr, source):
 
         unwrapped_expr = _unwrap_cached_nodes(xorq_expr)
 
+        # Detect SelfReference (from .view()) — must be preserved so that
+        # self-joins on the same underlying table get distinct ibis identities.
+        is_self_ref = isinstance(unwrapped_expr.op(), xorq_rel.SelfReference)
+
         read_ops = list(walk_nodes((Read,), unwrapped_expr))
         in_memory_tables = list(walk_nodes((xorq_rel.InMemoryTable,), unwrapped_expr))
         db_tables = list(walk_nodes((xorq_rel.DatabaseTable,), unwrapped_expr))
@@ -694,7 +698,13 @@ def _reconstruct_semantic_table(metadata: dict, xorq_expr, source):
             return from_ibis(expr) if not hasattr(expr.op(), "source") else expr
 
         if read_ops:
-            return read_ops[0].to_expr()
+            base = read_ops[0].to_expr()
+            # Wrap in .view() to give this table a unique identity when
+            # the original source was a SelfReference (e.g. airports_tbl.view()).
+            # Without this, two SemanticTableOps sharing the same underlying
+            # Read op collapse to the same ibis relation, causing
+            # "Ambiguous field reference" in multi-way joins.
+            return base.view() if is_self_ref else base
 
         if in_memory_tables:
             proxy = in_memory_tables[0].args[2]


### PR DESCRIPTION
## Summary
- When 3+ dimension tables share a column name (e.g. "code"), ibis raises "Ambiguous field reference"
- Fix: temp-rename conflicting left columns before join, use `_RenamedResolver` for predicate, rename back after
- Depth-based rename suffix (`_right`, `_right2`, `_right3`) avoids ibis `IntegrityError`

**Depends on:** #189

## Test plan
- [ ] Multi-way join with shared column names works without ambiguity errors
- [ ] `test_xorq_string_serialization.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)