### PR TITLE
fix: preserve mutated group-by columns in join_many pre-aggregation

### DIFF
--- a/src/boring_semantic_layer/ops.py
+++ b/src/boring_semantic_layer/ops.py
@@ -1871,16 +1871,35 @@ class SemanticAggregateOp(Relation):
         is_post_agg = has_prior_aggregate(self.source)
         collected_filters = collect_filters_to_join(self.source)
 
+        def collect_mutates_to_join(node):
+            """Collect SemanticMutateOp.post dicts between here and the join."""
+            mutates = []
+            current = node
+            while current is not None:
+                match current:
+                    case SemanticMutateOp():
+                        mutates.append(current.post)
+                        current = current.source
+                    case SemanticJoinOp() | SemanticTableOp():
+                        break
+                    case _ if hasattr(current, "source"):
+                        current = current.source
+                    case _:
+                        break
+            return tuple(mutates)
+
         # Pre-aggregation path: when join_many is present, aggregate each
         # source table's measures at its own grain before joining.
         if join_op is not None and not is_post_agg:
             join_tree_info = _collect_join_tree_info(join_op)
             if join_tree_info.has_join_many:
+                collected_mutates = collect_mutates_to_join(self.source)
                 return self._to_untagged_with_preagg(
                     all_roots,
                     join_op,
                     join_tree_info,
                     filters=collected_filters,
+                    mutates=collected_mutates,
                 )
 
         # Only use the join optimization if there are no filters after the join
@@ -1936,6 +1955,7 @@ class SemanticAggregateOp(Relation):
         join_op: SemanticJoinOp,
         join_tree_info: _JoinTreeInfo,
         filters: list | None = None,
+        mutates: tuple | None = None,
     ):
         """Pre-aggregate each source table's measures at its own grain, then join.
 
@@ -1947,6 +1967,19 @@ class SemanticAggregateOp(Relation):
         group_by_cols = list(self.keys)
 
         filters = filters or []
+        mutates = mutates or ()
+
+        # Identify group-by keys that come from .mutate() rather than
+        # semantic dimensions — these need special handling.  This is a
+        # process-of-elimination heuristic: any key that is not a known
+        # dimension, measure, or calc measure is assumed to originate
+        # from a .mutate() call in the operation chain.
+        mutated_gb_keys = frozenset(
+            k for k in group_by_cols
+            if k not in merged_dimensions
+            and k not in merged_base_measures
+            and k not in merged_calc_measures
+        )
 
         # --- 1. Try to build the full joined table (for scope / dim bridge) ---
         try:
@@ -1956,6 +1989,19 @@ class SemanticAggregateOp(Relation):
                 [k for k in self.keys if k in merged_dimensions],
                 merged_dimensions,
             )
+            # Apply mutate operations so mutated group-by keys are available
+            # on the full joined table (needed for dimension bridges).
+            if mutated_gb_keys:
+                for mutate_post in mutates:
+                    for name, fn_wrapped in mutate_post.items():
+                        if name in mutated_gb_keys:
+                            try:
+                                fn = _unwrap(fn_wrapped)
+                                resolved = _resolve_expr(fn, tbl)
+                                tbl = tbl.mutate(**{name: resolved})
+                            except (TypeError, KeyError, AttributeError,
+                                    ibis.common.exceptions.IbisTypeError):
+                                pass
             # Apply collected filters to the full joined table so that
             # dimension bridges only include rows surviving the filter.
             if filters:
@@ -2075,8 +2121,24 @@ class SemanticAggregateOp(Relation):
                                     raw_tbl = raw_tbl.inner_join(key_bridge, preds).select(raw_tbl)
                                     break
 
+            # Apply mutated group-by keys to this raw table so they can
+            # participate in the per-table grain computation.
+            if mutated_gb_keys:
+                for mutate_post in mutates:
+                    for name, fn_wrapped in mutate_post.items():
+                        if name in mutated_gb_keys and name not in raw_tbl.columns:
+                            try:
+                                fn = _unwrap(fn_wrapped)
+                                resolved = _resolve_expr(fn, raw_tbl)
+                                raw_tbl = raw_tbl.mutate(**{name: resolved})
+                            except (TypeError, KeyError, AttributeError,
+                                    ibis.common.exceptions.IbisTypeError):
+                                pass
+
             table_measures = _get_field_dict(table_op, "measures")
             table_dims = _get_field_dict(table_op, "dimensions")
+            # Captured after mutated-key application above so the grain
+            # computation can see the newly-added columns.
             raw_columns = set(raw_tbl.columns)
 
             # Build agg expressions on the raw table
@@ -2117,7 +2179,11 @@ class SemanticAggregateOp(Relation):
             _local_dims = []
             has_cross_table_gb = False
             for gb_key in group_by_cols:
-                if "." in gb_key:
+                # Mutated columns are already on raw_tbl (applied above)
+                if gb_key in mutated_gb_keys:
+                    if gb_key in raw_columns and gb_key not in _local_dims:
+                        _local_dims.append(gb_key)
+                elif "." in gb_key:
                     prefix, short = gb_key.split(".", 1)
                     if prefix == table_name and short in table_dims:
                         dim_fn = table_dims[short]

--- a/src/boring_semantic_layer/tests/test_query.py
+++ b/src/boring_semantic_layer/tests/test_query.py
@@ -1584,5 +1584,112 @@ class TestMeasureFilters:
         assert all(result["total_distance"] > 0)
 
 
+class TestMutateGroupByAggregateOnJoinMany:
+    """Regression tests for #187 — mutate → group_by → aggregate on a
+    join_many model must preserve the mutated group-by column."""
+
+    @pytest.fixture(scope="class")
+    def joined_model(self, con):
+        customers_df = pd.DataFrame(
+            {"cid": [1, 2], "name": ["Alice", "Bob"]}
+        )
+        accounts_df = pd.DataFrame(
+            {
+                "aid": [10, 11, 12, 13],
+                "cid": [1, 1, 2, 2],
+                "date": pd.to_datetime(
+                    ["2024-01-05", "2024-02-10", "2024-01-15", "2024-02-20"]
+                ),
+                "balance": [100, 200, 300, 400],
+            }
+        )
+        customers = con.create_table("customers_187", customers_df)
+        accounts = con.create_table("accounts_187", accounts_df)
+
+        cust_model = to_semantic_table(customers, "customers").with_dimensions(
+            cid=lambda t: t.cid,
+            name=lambda t: t.name,
+        )
+        acct_model = to_semantic_table(accounts, "accounts").with_dimensions(
+            aid=lambda t: t.aid,
+            cid=lambda t: t.cid,
+            date=lambda t: t.date,
+        ).with_measures(
+            total_balance=lambda t: t.balance.sum(),
+        )
+
+        return cust_model.join_many(
+            acct_model, on=lambda l, r: l.cid == r.cid
+        )
+
+    def test_mutate_groupby_aggregate_preserves_column(self, joined_model):
+        """Mutated column used as group-by key must appear in the result."""
+        result = (
+            joined_model
+            .mutate(period=ibis._["date"].truncate("M"))
+            .group_by("period")
+            .aggregate("accounts.total_balance")
+        )
+        df = result.execute()
+        assert "period" in df.columns, (
+            f"'period' missing from result columns: {list(df.columns)}"
+        )
+        assert len(df) == 2  # Jan and Feb
+
+    def test_mutate_groupby_aggregate_values_correct(self, joined_model):
+        """Values should be correctly aggregated per mutated group."""
+        result = (
+            joined_model
+            .mutate(period=ibis._["date"].truncate("M"))
+            .group_by("period")
+            .aggregate("accounts.total_balance")
+        )
+        df = result.execute().sort_values("period").reset_index(drop=True)
+        # Jan: 100 + 300 = 400, Feb: 200 + 400 = 600
+        assert df["accounts.total_balance"].tolist() == [400, 600]
+
+    def test_mutate_with_semantic_dim_groupby(self, joined_model):
+        """Mutated key + semantic dimension in group-by together."""
+        result = (
+            joined_model
+            .mutate(period=ibis._["date"].truncate("M"))
+            .group_by("period", "customers.name")
+            .aggregate("accounts.total_balance")
+        )
+        df = result.execute()
+        assert "period" in df.columns
+        assert "customers.name" in df.columns
+        assert len(df) == 4  # 2 months × 2 customers
+
+    def test_mutate_groupby_order_by(self, joined_model):
+        """order_by on a mutated group-by column should not raise."""
+        result = (
+            joined_model
+            .mutate(period=ibis._["date"].truncate("M"))
+            .group_by("period")
+            .aggregate("accounts.total_balance")
+            .order_by("period")
+        )
+        df = result.execute()
+        assert "period" in df.columns
+        assert list(df["period"]) == sorted(df["period"])
+
+    def test_multiple_mutated_groupby_keys(self, joined_model):
+        """Multiple mutated columns in group-by should all survive."""
+        result = (
+            joined_model
+            .mutate(
+                period=ibis._["date"].truncate("M"),
+                bal_bucket=ibis._["balance"] > 150,
+            )
+            .group_by("period", "bal_bucket")
+            .aggregate("accounts.total_balance")
+        )
+        df = result.execute()
+        assert "period" in df.columns
+        assert "bal_bucket" in df.columns
+        assert len(df) >= 2
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes #187 — `.mutate() → .group_by() → .aggregate()` on a `join_many` model silently drops the mutated group-by column from the result.

**Root cause:** `_to_untagged_with_preagg` only considers semantic dimensions when computing per-table grain, so mutated columns (from `.mutate()`) are never included in the pre-aggregation grain and get dropped.

**Fix:**
- Collect `SemanticMutateOp.post` dicts from the operation chain between aggregate and join
- Apply mutate expressions to the full joined table (for dimension bridges) and to per-table raw tables (best-effort, skipping tables that don't have the referenced columns)
- Include successfully-applied mutated columns in the per-table grain computation

## Test plan

- [x] 5 new regression tests in `TestMutateGroupByAggregateOnJoinMany`:
  - Mutated column appears in result columns
  - Aggregated values are correct per mutated group
  - Mutated key + semantic dimension together
  - `order_by` on mutated column works
  - Multiple mutated group-by columns
- [x] Exact bug report scenario from #187 verified manually
- [x] Full test suite: 630 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)