### PR TITLE
Adding FastAPI server as boring-semantic-layer[server]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ builds/
 
 # Cached example data
 examples/data/
+examples/*/data/
 examples/*.local.yml
 
 # Eval transcripts

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -1,0 +1,247 @@
+# BSL HTTP API Server — Example
+
+This example uses the **TPC-H** dataset (orders, lineitems, customers, etc.) to demonstrate the BSL FastAPI server.
+
+---
+
+## 1. Install dependencies
+
+```bash
+pip install 'boring-semantic-layer[server]'
+# also needed for the demo database:
+pip install duckdb
+```
+
+---
+
+## 2. Create a `semantic_config.py`
+
+The server loads models from a Python file that must expose a top-level `MODELS` dict. Each value is a `SemanticModel` or `SemanticTable` built with the BSL API.
+
+**Minimal example (single table):**
+
+```python
+import ibis
+from ibis import _
+import boring_semantic_layer as bsl
+
+conn = ibis.duckdb.connect("my_database.duckdb")
+
+sales = (
+    bsl.to_semantic_table(conn.table("sales"), name="sales")
+    .with_dimensions(
+        region=_.region,
+        product=_.product_name,
+        sale_date=_.sale_date,
+    )
+    .with_measures(
+        revenue=_.amount.sum(),
+        order_count=_.count(),
+        avg_order=_.amount.mean(),
+    )
+)
+
+MODELS = {
+    "sales": sales,
+}
+```
+
+Key rules:
+- `MODELS` must be a `dict[str, SemanticModel]` at module level — the server reads nothing else.
+- Dimension names and measure names become the field names used in API requests.
+- Any ibis-compatible backend works (DuckDB, PostgreSQL, BigQuery, etc.).
+
+The `semantic_config.py` in this folder uses the TPC-H demo database. See `scripts/generate_demo_db.py` to generate it.
+
+---
+
+## 3. Generate the demo database (optional)
+
+Skip this if you have your own database. Run from this folder:
+
+```bash
+python scripts/generate_demo_db.py
+```
+
+This creates `data/tpch.duckdb` (~12 MB at the default scale factor of 0.1).
+Increase `SF` in the script for more data (1.0 → ~120 MB).
+
+---
+
+## 4. Start the server
+
+From any directory, point `--config` at your `semantic_config.py`:
+
+```bash
+bsl serve --config ./examples/server/semantic_config.py
+```
+
+Additional options:
+
+```bash
+bsl serve --config ./semantic_config.py --host 0.0.0.0 --port 8000 --reload
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--config` | `./semantic_config.py` | Path to your config file |
+| `--host` | `0.0.0.0` | Bind address |
+| `--port` | `8000` | Port |
+| `--reload` | off | Auto-reload on code changes (dev only) |
+
+You can also set the config path via environment variable instead of `--config`:
+
+```bash
+export BSL_CONFIG_PATH=/path/to/semantic_config.py
+bsl serve
+```
+
+The interactive API docs are available at [http://localhost:8000/docs](http://localhost:8000/docs) once the server is running.
+
+---
+
+## 5. Send requests
+
+### List available models
+
+```bash
+curl http://localhost:8000/models
+```
+
+```json
+{"models": ["orders", "lineitem", "customer", "supplier", "part", "partsupp", "nation", "region", "region_to_nation_to_customer_to_orders"]}
+```
+
+### Inspect a model's schema
+
+```bash
+curl http://localhost:8000/models/orders/schema
+```
+
+```json
+{
+  "model": "orders",
+  "dimensions": [
+    {"name": "orderkey", "type": "integer"},
+    {"name": "custkey",  "type": "integer"},
+    {"name": "order_date", "type": "date"},
+    {"name": "status",   "type": "string"},
+    {"name": "priority", "type": "string"},
+    {"name": "clerk",    "type": "string"}
+  ],
+  "measures": ["total_price", "order_count", "avg_price"]
+}
+```
+
+### Run a query — dimensions + measures
+
+```bash
+curl -X POST http://localhost:8000/query \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "orders",
+    "dimensions": ["status"],
+    "measures": ["order_count", "total_price"],
+    "limit": 100
+  }'
+```
+
+```json
+{
+  "columns": ["status", "order_count", "total_price"],
+  "rows": [
+    ["F", 730160, 1082282971.33],
+    ["O", 733534, 1088816017.57],
+    ["P",   3817,    5765021.67]
+  ]
+}
+```
+
+### Filter results
+
+```bash
+curl -X POST http://localhost:8000/query \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "orders",
+    "dimensions": ["status", "priority"],
+    "measures": ["order_count", "total_price"],
+    "filters": [
+      {"dimension": "status", "op": "eq", "value": "O"}
+    ]
+  }'
+```
+
+Supported filter operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `contains`
+
+### Sort results
+
+```bash
+curl -X POST http://localhost:8000/query \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "orders",
+    "dimensions": ["status"],
+    "measures": ["order_count"],
+    "sort_by": [{"field": "order_count", "direction": "desc"}]
+  }'
+```
+
+### Time grain truncation
+
+Use `grains` to truncate date dimensions to year / quarter / month / date.
+The output column is renamed to `<dimension>.<grain>`.
+
+```bash
+curl -X POST http://localhost:8000/query \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "orders",
+    "dimensions": ["order_date"],
+    "measures": ["order_count", "total_price"],
+    "grains": {"order_date": "month"},
+    "sort_by": [{"field": "order_date.month", "direction": "asc"}],
+    "limit": 12
+  }'
+```
+
+```json
+{
+  "columns": ["order_date.month", "order_count", "total_price"],
+  "rows": [
+    ["1992-01-01", 5765, 8534221.10],
+    ["1992-02-01", 5244, 7762340.88],
+    ...
+  ]
+}
+```
+
+### Health check
+
+```bash
+curl http://localhost:8000/health
+```
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## Query request reference
+
+`POST /query`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `model` | string | yes | Name from `MODELS` in your config |
+| `dimensions` | string[] | no | Dimension names to select/group by |
+| `measures` | string[] | no | Measure names to aggregate |
+| `filters` | FilterClause[] | no | Row-level filters |
+| `sort_by` | SortClause[] | no | Output sort order |
+| `grains` | dict | no | Time grain per dimension (`year`/`quarter`/`month`/`date`) |
+| `limit` | int | no | Max rows returned (default 1000, max 100 000) |
+
+**FilterClause:** `{"dimension": "<name>", "op": "<op>", "value": "<value>"}`
+
+**SortClause:** `{"field": "<dimension-or-measure>", "direction": "asc" | "desc"}`

--- a/examples/server/scripts/generate_demo_db.py
+++ b/examples/server/scripts/generate_demo_db.py
@@ -1,0 +1,35 @@
+"""
+Generate the TPC-H demo DuckDB database.
+
+Run from this folder (examples/server/):
+    python scripts/generate_demo_db.py
+
+Scale factor (sf):
+  0.01 → ~1 MB,  fast
+  0.1  → ~12 MB, default (good for demos)
+  1.0  → ~120 MB, more realistic
+
+The generated file is saved to examples/server/data/tpch.duckdb.
+"""
+import pathlib
+import duckdb
+
+SF = 0.1
+DB_PATH = pathlib.Path(__file__).parent.parent / "data" / "tpch.duckdb"
+
+DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+print(f"Generating TPC-H database at {DB_PATH} (scale factor={SF})...")
+conn = duckdb.connect(str(DB_PATH))
+conn.execute("INSTALL tpch;")
+conn.execute("LOAD tpch;")
+conn.execute(f"CALL dbgen(sf={SF});")
+
+tables = conn.execute("SHOW TABLES;").fetchall()
+print("Tables created:")
+for (tbl,) in tables:
+    count = conn.execute(f"SELECT count(*) FROM {tbl}").fetchone()[0]
+    print(f"  {tbl}: {count:,} rows")
+
+conn.close()
+print(f"\nDone. Database saved to {DB_PATH.resolve()}")

--- a/examples/server/semantic_config.py
+++ b/examples/server/semantic_config.py
@@ -1,0 +1,162 @@
+"""
+semantic_config.py — Edit this file to define your semantic models.
+
+Each SemanticModel wraps a DuckDB table and declares:
+  - dimensions: columns or expressions used to group/slice data
+  - measures:   aggregations (sum, count, avg, etc.)
+
+The MODELS dict at the bottom is required — main.py and the API import from it.
+"""
+import ibis
+from ibis import _
+import pathlib
+import boring_semantic_layer as bsl
+
+# Connect to DuckDB (change the path if you use a different file)
+DB_PATH = pathlib.Path(__file__).parent / "data" / "tpch.duckdb"
+conn = ibis.duckdb.connect(str(DB_PATH))
+
+# define semantic tables
+orders = bsl.to_semantic_table(
+        conn.table("orders"),
+        name="orders"
+    ).with_dimensions(
+        orderkey=_.o_orderkey,
+        custkey=_.o_custkey,
+        order_date=_.o_orderdate,
+        status=_.o_orderstatus,
+        priority=_.o_orderpriority,
+        clerk=_.o_clerk,
+    ).with_measures(
+        total_price=_.o_totalprice.sum(),
+        order_count=_.count(),
+        avg_price=_.o_totalprice.mean(),
+    )
+
+lineitem = bsl.to_semantic_table(
+        conn.table("lineitem"),
+        name="lineitem"
+    ).with_dimensions(
+        orderkey=_.l_orderkey,
+        partkey=_.l_partkey,
+        suppkey=_.l_suppkey,
+        ship_mode=_.l_shipmode,
+        return_flag=_.l_returnflag,
+        line_status=_.l_linestatus,
+        ship_date=_.l_shipdate,
+    ).with_measures(
+        quantity=_.l_quantity.sum(),
+        revenue=_.l_extendedprice.sum(),
+        avg_discount=_.l_discount.mean(),
+        line_count=_.count(),
+    )
+
+customer = bsl.to_semantic_table(
+        conn.table("customer"),
+        name="customer"
+    ).with_dimensions(
+        custkey=_.c_custkey,
+        nationkey=_.c_nationkey,
+        mktsegment=_.c_mktsegment,
+        phone=_.c_phone,
+    ).with_measures(
+        customer_count=_.count(),
+        total_acctbal=_.c_acctbal.sum(),
+        avg_acctbal=_.c_acctbal.mean(),
+    )
+
+supplier = bsl.to_semantic_table(
+        conn.table("supplier"),
+        name="supplier"
+    ).with_dimensions(
+        suppkey=_.s_suppkey,
+        nationkey=_.s_nationkey,
+        phone=_.s_phone,
+    ).with_measures(
+        supplier_count=_.count(),
+        total_acctbal=_.s_acctbal.sum(),
+        avg_acctbal=_.s_acctbal.mean(),
+    )
+
+part = bsl.to_semantic_table(
+        conn.table("part"),
+        name="part"
+    ).with_dimensions(
+        partkey=_.p_partkey,
+        brand=_.p_brand,
+        type=_.p_type,
+        size=_.p_size,
+        container=_.p_container,
+        mfgr=_.p_mfgr,
+    ).with_measures(
+        part_count=_.count(),
+        avg_retail_price=_.p_retailprice.mean(),
+        total_retail_price=_.p_retailprice.sum(),
+    )
+
+partsupp = bsl.to_semantic_table(
+        conn.table("partsupp"),
+        name="partsupp"
+    ).with_dimensions(
+        partkey=_.ps_partkey,
+        suppkey=_.ps_suppkey,
+    ).with_measures(
+        total_availqty=_.ps_availqty.sum(),
+        avg_availqty=_.ps_availqty.mean(),
+        total_supplycost=_.ps_supplycost.sum(),
+        avg_supplycost=_.ps_supplycost.mean(),
+        partsupp_count=_.count(),
+    )
+
+nation = bsl.to_semantic_table(
+        conn.table("nation"),
+        name="nation"
+    ).with_dimensions(
+        nationkey=_.n_nationkey,
+        regionkey=_.n_regionkey,
+        name=_.n_name,
+    ).with_measures(
+        nation_count=_.count(),
+    )
+
+region = bsl.to_semantic_table(
+        conn.table("region"),
+        name="region"
+    ).with_dimensions(
+        regionkey=_.r_regionkey,
+        name=_.r_name,
+    ).with_measures(
+        region_count=_.count(),
+    )
+
+
+# Create Semantic Models
+
+# Region to Nation
+region_to_nation = region.join_one(
+    nation,
+    lambda r, n: r.r_regionkey == n.n_regionkey
+)
+
+region_to_nation_to_customer = region_to_nation.join_one(
+    customer,
+    lambda r, c: r.n_nationkey == c.c_nationkey
+)
+
+region_to_nation_to_customer_to_orders = region_to_nation_to_customer.join_one(
+    orders,
+    lambda r, o: r.c_custkey == o.o_custkey
+)
+
+# REQUIRED: the API reads this dict to discover available models
+MODELS = {
+    "orders":          orders,
+    "lineitem":        lineitem,
+    "customer":        customer,
+    "supplier":        supplier,
+    "part":            part,
+    "partsupp":        partsupp,
+    "nation":          nation,
+    "region":          region,
+    "region_to_nation_to_customer_to_orders":  region_to_nation_to_customer_to_orders
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,14 @@ mcp = [
     "fastmcp>=2.12.4",
 ]
 
+# HTTP API server
+server = [
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.30.0",
+]
+
 dev = [
-    "boring-semantic-layer[agent,mcp,examples,viz-altair,viz-plotly,viz-plotext]",
+    "boring-semantic-layer[agent,mcp,server,examples,viz-altair,viz-plotly,viz-plotext]",
     "openai>=1.0.0",
     "langchain-openai>=0.3.0",
     "langchain-anthropic>=0.3.0",

--- a/src/boring_semantic_layer/agents/cli.py
+++ b/src/boring_semantic_layer/agents/cli.py
@@ -263,6 +263,23 @@ def cmd_render(args):
             observer.join()
 
 
+def cmd_serve(args):
+    """Start the BSL HTTP API server."""
+    try:
+        from boring_semantic_layer.server import main as serve_main
+    except ImportError:
+        print("❌ FastAPI/uvicorn not installed.")
+        print("   Install with: pip install 'boring-semantic-layer[server]'")
+        return
+
+    serve_main(
+        config=getattr(args, "config", None),
+        host=args.host,
+        port=args.port,
+        reload=args.reload,
+    )
+
+
 def cmd_chat(args):
     """Start an interactive chat session with the semantic model."""
     import os
@@ -398,6 +415,34 @@ def main():
         help="Exit after running the initial query (non-interactive mode)",
     )
     chat_parser.set_defaults(func=cmd_chat)
+
+    # Serve command
+    serve_parser = subparsers.add_parser(
+        "serve",
+        help="Start the BSL HTTP API server (requires boring-semantic-layer[server])",
+    )
+    serve_parser.add_argument(
+        "--config",
+        type=str,
+        help="Path to semantic_config.py (default: ./semantic_config.py or BSL_CONFIG_PATH env var)",
+    )
+    serve_parser.add_argument(
+        "--host",
+        default="0.0.0.0",
+        help="Host to bind to (default: 0.0.0.0)",
+    )
+    serve_parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port to listen on (default: 8000)",
+    )
+    serve_parser.add_argument(
+        "--reload",
+        action="store_true",
+        help="Enable auto-reload on code changes (development only)",
+    )
+    serve_parser.set_defaults(func=cmd_serve)
 
     # Skill command with subcommands
     skill_parser = subparsers.add_parser(

--- a/src/boring_semantic_layer/server/__init__.py
+++ b/src/boring_semantic_layer/server/__init__.py
@@ -1,0 +1,39 @@
+"""FastAPI HTTP server for boring-semantic-layer.
+
+Start with:
+    bsl serve --config ./semantic_config.py
+
+or programmatically:
+    from boring_semantic_layer.server import main
+    main(config="./semantic_config.py", port=8000)
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+
+
+def main(
+    config: str | None = None,
+    host: str = "0.0.0.0",
+    port: int = 8000,
+    reload: bool = False,
+) -> None:
+    """Start the BSL FastAPI server with uvicorn."""
+    try:
+        import uvicorn
+    except ImportError:
+        raise ImportError(
+            "uvicorn is required to run the BSL server. "
+            "Install it with: pip install 'boring-semantic-layer[server]'"
+        )
+
+    if config:
+        os.environ["BSL_CONFIG_PATH"] = str(pathlib.Path(config).resolve())
+
+    uvicorn.run(
+        "boring_semantic_layer.server.api:app",
+        host=host,
+        port=port,
+        reload=reload,
+    )

--- a/src/boring_semantic_layer/server/api.py
+++ b/src/boring_semantic_layer/server/api.py
@@ -1,0 +1,276 @@
+"""FastAPI application exposing boring_semantic_layer models over HTTP.
+
+All responses are JSON. CORS is open for local use — lock down allow_origins
+before any non-local deployment.
+"""
+from __future__ import annotations
+
+import datetime
+import decimal
+import traceback
+from typing import Literal
+
+import ibis
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+import pandas as pd
+
+from boring_semantic_layer.server.loader import load_models
+
+app = FastAPI(title="Boring Semantic Layer API", version="0.1.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.exception_handler(Exception)
+async def global_exception_handler(request: Request, exc: Exception):
+    traceback.print_exc()
+    return JSONResponse(status_code=500, content={"error": str(exc)})
+
+
+# Load models once at startup
+MODELS = load_models()
+
+# ---------------------------------------------------------------------------
+# Request / response schemas
+# ---------------------------------------------------------------------------
+
+FILTER_OPS = {"eq", "neq", "gt", "gte", "lt", "lte", "contains"}
+
+VALID_GRAINS = {"year", "quarter", "month", "date"}
+_GRAIN_TRUNCATE = {"year": "year", "quarter": "quarter", "month": "month", "date": "day"}
+
+
+class FilterClause(BaseModel):
+    dimension: str
+    op: str
+    value: str
+
+
+class SortClause(BaseModel):
+    field: str
+    direction: Literal["asc", "desc"] = "asc"
+
+
+class QueryRequest(BaseModel):
+    model: str
+    dimensions: list[str] = []
+    measures: list[str] = []
+    filters: list[FilterClause] = []
+    sort_by: list[SortClause] = []
+    grains: dict[str, Literal["year", "quarter", "month", "date"]] = {}
+    limit: int = Field(default=1000, ge=1, le=100_000)
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+
+@app.get("/models")
+def list_models():
+    return {"models": list(MODELS.keys())}
+
+
+@app.get("/models/{model_name}/schema")
+def model_schema(model_name: str):
+    if model_name not in MODELS:
+        raise HTTPException(status_code=404, detail=f"Model '{model_name}' not found.")
+    sm = MODELS[model_name]
+    tbl = sm.table
+    all_dims = sm.get_dimensions()
+
+    dim_info = []
+    for name, dim_fn in all_dims.items():
+        try:
+            type_str = _ibis_type_to_str(dim_fn(tbl).type())
+        except Exception:
+            type_str = "string"
+        dim_info.append({"name": name, "type": type_str})
+
+    return {
+        "model": model_name,
+        "dimensions": dim_info,
+        "measures": list(sm.get_measures().keys()),
+    }
+
+
+@app.post("/query")
+def run_query(req: QueryRequest):
+    if req.model not in MODELS:
+        raise HTTPException(status_code=404, detail=f"Model '{req.model}' not found.")
+
+    sm = MODELS[req.model]
+    all_dims = sm.get_dimensions()
+    all_meas = sm.get_measures()
+
+    for d in req.dimensions:
+        if d not in all_dims:
+            raise HTTPException(status_code=400, detail=f"Unknown dimension: '{d}'")
+    for m in req.measures:
+        if m not in all_meas:
+            raise HTTPException(status_code=400, detail=f"Unknown measure: '{m}'")
+
+    for dim_name in req.grains:
+        if dim_name not in req.dimensions:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Grain specified for '{dim_name}' which is not in the selected dimensions.",
+            )
+
+    ibis_filters = []
+    for f in req.filters:
+        if f.dimension not in all_dims:
+            raise HTTPException(status_code=400, detail=f"Unknown filter field: '{f.dimension}'")
+        if f.op not in FILTER_OPS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unknown operator: '{f.op}'. Use one of {sorted(FILTER_OPS)}",
+            )
+        ibis_filters.append(_make_filter(all_dims[f.dimension], f.op, f.value, sm.table))
+
+    if req.sort_by:
+        output_dim_names = {
+            f"{d}.{req.grains[d]}" if d in req.grains else d for d in req.dimensions
+        }
+        valid_fields = output_dim_names | set(req.measures)
+        for s in req.sort_by:
+            if s.field not in valid_fields:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Sort field '{s.field}' is not in the query output.",
+                )
+
+    try:
+        if req.grains:
+            result_df = _run_grained_query(sm, all_dims, all_meas, req, ibis_filters)
+        else:
+            order_by_param = [(s.field, s.direction) for s in req.sort_by] if req.sort_by else None
+            query_expr = sm.query(
+                dimensions=req.dimensions or None,
+                measures=req.measures or None,
+                filters=ibis_filters if ibis_filters else None,
+                order_by=order_by_param,
+                limit=req.limit,
+            )
+            result_df = query_expr.execute()
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+    columns = list(result_df.columns)
+    rows = [[_json_safe(v) for v in row] for row in result_df.itertuples(index=False)]
+    return {"columns": columns, "rows": rows}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_filter(dim_obj, op: str, val: str, tbl):
+    col = dim_obj(tbl)
+    if op == "eq":
+        return lambda t: dim_obj(t) == _cast(col, val)
+    elif op == "neq":
+        return lambda t: dim_obj(t) != _cast(col, val)
+    elif op == "gt":
+        return lambda t: dim_obj(t) > _cast(col, val)
+    elif op == "gte":
+        return lambda t: dim_obj(t) >= _cast(col, val)
+    elif op == "lt":
+        return lambda t: dim_obj(t) < _cast(col, val)
+    elif op == "lte":
+        return lambda t: dim_obj(t) <= _cast(col, val)
+    elif op == "contains":
+        return lambda t: dim_obj(t).contains(val)
+    else:
+        raise ValueError(f"Unhandled operator: '{op}'")
+
+
+def _cast(col_expr, value: str):
+    dtype = col_expr.type()
+    if dtype.is_numeric():
+        try:
+            return float(value) if "." in value else int(value)
+        except ValueError:
+            return value
+    return value
+
+
+def _json_safe(v):
+    if isinstance(v, (datetime.date, datetime.datetime)):
+        return v.isoformat()
+    if isinstance(v, decimal.Decimal):
+        return float(v)
+    return v
+
+
+def _ibis_type_to_str(dtype) -> str:
+    if dtype.is_date():
+        return "date"
+    if dtype.is_timestamp():
+        return "timestamp"
+    if dtype.is_integer():
+        return "integer"
+    if dtype.is_floating() or dtype.is_decimal():
+        return "float"
+    return "string"
+
+
+def _run_grained_query(sm, all_dims, all_meas, req, ibis_filters):
+    """Execute a query applying time grain truncations to the specified dimensions."""
+
+    tbl = sm.table
+
+    if ibis_filters:
+        tbl = tbl.filter([f(tbl) for f in ibis_filters])
+
+    dim_exprs = []
+    for d in req.dimensions:
+        col = all_dims[d](tbl)
+        grain = req.grains.get(d)
+        if grain:
+            col = col.truncate(_GRAIN_TRUNCATE[grain])
+            col_label = f"{d}.{grain}"
+        else:
+            col_label = d
+        dim_exprs.append(col.name(col_label))
+
+    agg_exprs = [all_meas[m](tbl).name(m) for m in req.measures]
+
+    if dim_exprs and agg_exprs:
+        query = tbl.group_by(dim_exprs).aggregate(agg_exprs)
+    elif dim_exprs:
+        query = tbl.select(dim_exprs).distinct()
+    else:
+        query = tbl.aggregate(agg_exprs)
+
+    if req.sort_by:
+        order_exprs = [
+            ibis.desc(s.field) if s.direction == "desc" else s.field for s in req.sort_by
+        ]
+        query = query.order_by(order_exprs)
+
+    result_df = query.limit(req.limit).execute()
+
+    for dim_name, grain in req.grains.items():
+        col_label = f"{dim_name}.{grain}"
+        if col_label in result_df.columns:
+            result_df[col_label] = pd.to_datetime(result_df[col_label]).dt.date
+
+    return result_df

--- a/src/boring_semantic_layer/server/loader.py
+++ b/src/boring_semantic_layer/server/loader.py
@@ -1,0 +1,37 @@
+"""Dynamically loads a semantic_config.py and returns its MODELS dict.
+
+Config path resolution order:
+  1. Explicit path passed to load_models()
+  2. BSL_CONFIG_PATH environment variable
+  3. semantic_config.py in the current working directory
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import pathlib
+
+
+def load_models(config_path: str | pathlib.Path | None = None):
+    if config_path is None:
+        env_path = os.environ.get("BSL_CONFIG_PATH")
+        config_path = pathlib.Path(env_path) if env_path else pathlib.Path("semantic_config.py")
+
+    config_path = pathlib.Path(config_path).resolve()
+
+    if not config_path.exists():
+        raise FileNotFoundError(
+            f"Config file not found at {config_path}. "
+            "Pass --config <path> to bsl serve or set the BSL_CONFIG_PATH environment variable."
+        )
+
+    spec = importlib.util.spec_from_file_location("semantic_config", config_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    if not hasattr(mod, "MODELS"):
+        raise AttributeError(
+            f"{config_path} must define a top-level dict named MODELS."
+        )
+
+    return mod.MODELS


### PR DESCRIPTION
This PR introduces an optional HTTP API server that exposes BSL semantic models over REST, making it easy to query them from any language or tool without a Python runtime.

Summary
New server optional dependency — adds fastapi and uvicorn as an opt-in extra (pip install 'boring-semantic-layer[server]')
bsl serve CLI command — starts the FastAPI server, accepting --config, --host, --port, and --reload flags; config path falls back to BSL_CONFIG_PATH env var or ./semantic_config.py
Three REST endpoints:
GET /health — liveness check
GET /models / GET /models/{name}/schema — introspect available models and their dimensions/measures
POST /query — run queries with dimensions, measures, filters (eq/neq/gt/gte/lt/lte/contains), sorting, time-grain truncation (year/quarter/month/date), and limit
Dynamic config loader (server/loader.py) — imports semantic_config.py at startup via importlib, no hardcoded imports required
Example server config (examples/server/) — demo Duck DB generator and a sample semantic_config.py with full README