### PR TITLE
feat: deferred join_one — dimension lookups after aggregation

### DIFF
--- a/src/boring_semantic_layer/expr.py
+++ b/src/boring_semantic_layer/expr.py
@@ -424,6 +424,42 @@ def _build_semantic_model_from_roots(
     )
 
 
+def _get_entity_dims(op) -> frozenset[str]:
+    """Return the set of dimension names marked ``is_entity=True`` on an op."""
+    from .ops import SemanticTableOp
+
+    if isinstance(op, SemanticTableOp):
+        return frozenset(
+            name for name, dim in op.get_dimensions().items() if getattr(dim, "is_entity", False)
+        )
+    return frozenset()
+
+
+def _detect_grain_cardinality(left_op, right_op) -> str:
+    """Compare entity dimensions to detect grain mismatch.
+
+    If both sides declare ``is_entity`` dimensions and the sets differ,
+    returns ``"many"`` so BSL's pre-aggregation logic aligns the grains.
+    Otherwise returns ``"one"`` (standard join_one behaviour).
+    """
+    import warnings
+
+    left_entities = _get_entity_dims(left_op)
+    right_entities = _get_entity_dims(right_op)
+
+    if left_entities and right_entities and left_entities != right_entities:
+        left_name = getattr(left_op, "name", None) or "left"
+        right_name = getattr(right_op, "name", None) or "right"
+        warnings.warn(
+            f"Grain mismatch detected: {left_name} entity dims {sorted(left_entities)} "
+            f"!= {right_name} entity dims {sorted(right_entities)}. "
+            f"Upgrading join_one to join_many for automatic pre-aggregation.",
+            stacklevel=2,
+        )
+        return "many"
+    return "one"
+
+
 class SemanticModel(SemanticTable):
     def __init__(
         self,
@@ -558,6 +594,11 @@ class SemanticModel(SemanticTable):
     ) -> SemanticJoin:
         """Join with one-to-one relationship semantics.
 
+        When both models have ``is_entity`` dimensions declared and their entity
+        sets differ, the join is automatically upgraded to ``join_many`` semantics
+        so that BSL's pre-aggregation logic can align the grains before joining.
+        This prevents fan-out / double-counting in multi-fact star schemas.
+
         Args:
             other: The semantic model to join with
             on: Join predicate. Accepts a lambda ``(left, right) -> bool``, a column
@@ -574,7 +615,8 @@ class SemanticModel(SemanticTable):
             >>> orders.join_one(customers, on=lambda o, c: o.customer_id == c.customer_id)
         """
         other_op = other.op() if isinstance(other, SemanticModel) else other
-        return SemanticJoin(left=self.op(), right=other_op, on=on, how=how, cardinality="one")
+        cardinality = _detect_grain_cardinality(self.op(), other_op)
+        return SemanticJoin(left=self.op(), right=other_op, on=on, how=how, cardinality=cardinality)
 
     def join_many(
         self,

--- a/src/boring_semantic_layer/expr.py
+++ b/src/boring_semantic_layer/expr.py
@@ -438,16 +438,25 @@ def _get_entity_dims(op) -> frozenset[str]:
 def _detect_grain_cardinality(left_op, right_op) -> str:
     """Compare entity dimensions to detect grain mismatch.
 
-    If both sides declare ``is_entity`` dimensions and the sets differ,
-    returns ``"many"`` so BSL's pre-aggregation logic aligns the grains.
-    Otherwise returns ``"one"`` (standard join_one behaviour).
+    If both sides declare ``is_entity`` dimensions, their entity sets differ,
+    and the right side has measures (i.e., it's a fact table, not a pure
+    dimension lookup), returns ``"many"`` so BSL's pre-aggregation logic
+    aligns the grains.  Pure dimension tables (no measures) stay ``"one"``
+    so they can use the more efficient deferred-join path.
     """
     import warnings
+
+    from .ops import SemanticTableOp
 
     left_entities = _get_entity_dims(left_op)
     right_entities = _get_entity_dims(right_op)
 
     if left_entities and right_entities and left_entities != right_entities:
+        # Don't upgrade for pure dimension tables (no measures) — these
+        # are lookup joins handled more efficiently by deferred join_one.
+        if isinstance(right_op, SemanticTableOp) and not right_op.get_measures():
+            return "one"
+
         left_name = getattr(left_op, "name", None) or "left"
         right_name = getattr(right_op, "name", None) or "right"
         warnings.warn(

--- a/src/boring_semantic_layer/ops.py
+++ b/src/boring_semantic_layer/ops.py
@@ -1745,6 +1745,7 @@ def _find_deferrable_joins(
     agg_names: dict,
     all_roots: list,
     join_tree_info: "_JoinTreeInfo",
+    filters: list | None = None,
 ) -> list[_DeferrableJoin]:
     """Identify join_one ops that can be deferred until after aggregation.
 
@@ -1752,8 +1753,26 @@ def _find_deferrable_joins(
     - cardinality == "one"
     - Right table has is_entity dims matching the join key
     - No measures from right table are used in the aggregation
+    - No filters reference the right table's columns
     """
+    filters = filters or []
     deferrable: list[_DeferrableJoin] = []
+
+    def _filter_references_table(table_name, table_op):
+        """Check if any filter predicate references columns from this table."""
+        if not filters:
+            return False
+        raw_tbl = _to_untagged(table_op)
+        for pred in filters:
+            pred_fn = _unwrap(pred)
+            try:
+                # If the predicate can be resolved against this table,
+                # it references its columns → can't defer
+                pred_fn(raw_tbl)
+                return True
+            except Exception:
+                pass
+        return False
 
     def walk(node):
         if not isinstance(node, SemanticJoinOp):
@@ -1770,6 +1789,10 @@ def _find_deferrable_joins(
 
         right_name = right.name
         if not right_name:
+            return
+
+        # Check: no filters reference the right table
+        if _filter_references_table(right_name, right):
             return
 
         # Check: right table has is_entity dims

--- a/src/boring_semantic_layer/ops.py
+++ b/src/boring_semantic_layer/ops.py
@@ -1735,7 +1735,7 @@ class _DeferrableJoin:
     table_name: str  # Name of the right (dimension) table
     table_op: Any  # SemanticTableOp of the right table
     join_keys_left: tuple  # Column names on the left side of the join
-    join_keys_right: tuple  # Column names on the right side of the join
+    on_predicate: Any  # Original join predicate (preserves key pairing)
     deferred_dims: tuple  # Prefixed dimension names to add post-agg
 
 
@@ -1847,7 +1847,7 @@ def _find_deferrable_joins(
             table_name=right_name,
             table_op=right,
             join_keys_left=left_cols,
-            join_keys_right=tuple(sorted(right_join_keys)),
+            on_predicate=node.on,
             deferred_dims=deferred_dims,
         ))
 
@@ -2822,11 +2822,9 @@ class SemanticAggregateOp(Relation):
         for d in deferrable:
             dim_tbl = _to_untagged(d.table_op)
 
-            # Build join predicate: result.left_key == dim_tbl.right_key
-            join_preds = [
-                result[lk] == dim_tbl[rk]
-                for lk, rk in zip(d.join_keys_left, d.join_keys_right)
-            ]
+            # Reuse the original join predicate to preserve key pairing
+            # (avoids mismatch from independently sorting left/right keys)
+            join_preds = d.on_predicate(result, dim_tbl)
 
             # Compute deferred dimension columns on the dimension table.
             # For direct columns (e.g., cc_name) this is a no-op rename.

--- a/src/boring_semantic_layer/ops.py
+++ b/src/boring_semantic_layer/ops.py
@@ -1675,17 +1675,6 @@ def _build_aggregation_plan(
 
 
 @frozen
-class _DeferrableJoinOne:
-    """Info about a join_one right-side table that may be deferred."""
-
-    table_name: str
-    on: Any  # join predicate callable
-    table_op: Any  # SemanticTableOp
-    left_join_cols: frozenset  # columns from left side used in join predicate
-    right_join_cols: frozenset  # columns from right side used in join predicate
-
-
-@frozen
 class _JoinTreeInfo:
     """Information collected from the join tree for pre-aggregation decisions."""
 
@@ -1693,45 +1682,18 @@ class _JoinTreeInfo:
     table_cardinalities: dict  # table_name → "one"|"many"|"root"
     table_join_keys: dict  # table_name → {raw_col_names}
     table_ops: dict  # table_name → SemanticTableOp
-    join_one_info: tuple  # tuple of _DeferrableJoinOne for join_one right-side tables
 
 
 def _collect_join_tree_info(join_op: SemanticJoinOp) -> _JoinTreeInfo:
     """Walk the join tree to collect cardinality and join key information."""
     table_cardinalities: dict[str, str] = {}
     table_ops: dict[str, SemanticTableOp] = {}
-    join_one_entries: list[_DeferrableJoinOne] = []
 
     def walk(node, is_right_of_many=False):
         if isinstance(node, SemanticJoinOp):
             this_is_many = node.cardinality in ("many", "cross")
             walk(node.left, is_right_of_many=is_right_of_many)
             walk(node.right, is_right_of_many=is_right_of_many or this_is_many)
-            # Collect join_one info for right-side leaf tables
-            if node.cardinality == "one" and isinstance(node.right, SemanticTableOp):
-                right_name = node.right.name
-                if right_name and node.on is not None:
-                    # Extract join key columns from the predicate
-                    try:
-                        left_tbl = (
-                            node.left.to_untagged(parent_requirements=None)
-                            if isinstance(node.left, SemanticJoinOp)
-                            else _to_untagged(node.left)
-                        )
-                        right_tbl = _to_untagged(node.right)
-                        jk = _extract_join_key_columns(node.on, left_tbl, right_tbl)
-                        if jk.is_success():
-                            join_one_entries.append(
-                                _DeferrableJoinOne(
-                                    table_name=right_name,
-                                    on=node.on,
-                                    table_op=node.right,
-                                    left_join_cols=jk.left_columns,
-                                    right_join_cols=jk.right_columns,
-                                )
-                            )
-                    except Exception:
-                        pass  # If extraction fails, don't track for deferral
         elif isinstance(node, SemanticTableOp):
             name = node.name
             if name:
@@ -1754,18 +1716,120 @@ def _collect_join_tree_info(join_op: SemanticJoinOp) -> _JoinTreeInfo:
         table_cardinalities[root_name] = "root"
 
     has_join_many = any(c == "many" for c in table_cardinalities.values())
-    # table_join_keys is only used by the pre-aggregation path
-    # (has_join_many=True).  Skip the potentially expensive call when
-    # all joins are join_one.
-    table_join_keys = join_op._collect_join_keys_for_leaves() if has_join_many else {}
+    # table_join_keys is used by the pre-aggregation path and by
+    # deferred join detection.  Collect for all join trees.
+    table_join_keys = join_op._collect_join_keys_for_leaves()
 
     return _JoinTreeInfo(
         has_join_many=has_join_many,
         table_cardinalities=table_cardinalities,
         table_join_keys=table_join_keys,
         table_ops=table_ops,
-        join_one_info=tuple(join_one_entries),
     )
+
+
+@frozen
+class _DeferrableJoin:
+    """A join_one that can be deferred until after aggregation."""
+
+    table_name: str  # Name of the right (dimension) table
+    table_op: Any  # SemanticTableOp of the right table
+    join_keys_left: tuple  # Column names on the left side of the join
+    join_keys_right: tuple  # Column names on the right side of the join
+    deferred_dims: tuple  # Prefixed dimension names to add post-agg
+
+
+def _find_deferrable_joins(
+    join_op,
+    group_by_keys: tuple[str, ...],
+    agg_names: dict,
+    all_roots: list,
+    join_tree_info: "_JoinTreeInfo",
+) -> list[_DeferrableJoin]:
+    """Identify join_one ops that can be deferred until after aggregation.
+
+    A join is deferrable when:
+    - cardinality == "one"
+    - Right table has is_entity dims matching the join key
+    - No measures from right table are used in the aggregation
+    """
+    deferrable: list[_DeferrableJoin] = []
+
+    def walk(node):
+        if not isinstance(node, SemanticJoinOp):
+            return
+        # Recurse into left side (may have nested joins)
+        walk(node.left)
+
+        if node.cardinality != "one":
+            return
+
+        right = node.right
+        if not isinstance(right, SemanticTableOp):
+            return
+
+        right_name = right.name
+        if not right_name:
+            return
+
+        # Check: right table has is_entity dims
+        right_dims = right.get_dimensions()
+        entity_dims = frozenset(
+            name for name, dim in right_dims.items()
+            if getattr(dim, "is_entity", False)
+        )
+        if not entity_dims:
+            return
+
+        # Check: no measures from right table are used in aggregation
+        for agg_name in agg_names:
+            if agg_name.startswith(f"{right_name}."):
+                return  # Right table has measures in agg → can't defer
+
+        # Get join keys for the right table
+        right_join_keys = join_tree_info.table_join_keys.get(right_name, set())
+        if not right_join_keys:
+            return
+
+        # Check: entity dims match join keys (PK = join key)
+        if entity_dims != frozenset(right_join_keys):
+            return
+
+        # Get left-side join keys by extracting from the predicate
+        try:
+            left_tbl = (
+                node.left.to_untagged(parent_requirements=None)
+                if isinstance(node.left, SemanticJoinOp)
+                else _to_untagged(node.left)
+            )
+            right_tbl = _to_untagged(right)
+            join_keys_result = _extract_join_key_columns(node.on, left_tbl, right_tbl)
+            if not join_keys_result.is_success():
+                return
+            left_cols = tuple(sorted(join_keys_result.left_columns))
+        except Exception:
+            return
+
+        # Identify which group-by dimensions from the right table will be deferred
+        deferred_dims = tuple(
+            k for k in group_by_keys
+            if k.startswith(f"{right_name}.")
+        )
+
+        # Only deferrable if there are dims to add post-agg
+        if not deferred_dims:
+            return
+
+        deferrable.append(_DeferrableJoin(
+            table_name=right_name,
+            table_op=right,
+            join_keys_left=left_cols,
+            join_keys_right=tuple(sorted(right_join_keys)),
+            deferred_dims=deferred_dims,
+        ))
+
+    walk(join_op)
+    return deferrable
 
 
 def _left_join_bridge(left, bridge, common_keys):
@@ -2152,57 +2216,20 @@ class SemanticAggregateOp(Relation):
                     mutates=collected_mutates,
                 )
 
-            # Deferred join_one path: when all joins are join_one, check
-            # if any right-side tables can be deferred to post-aggregation.
-            # A join_one right table is deferrable when:
-            #   - None of its prefixed dimensions appear in the GROUP BY keys
-            #   - None of its prefixed measures appear in the aggregation specs
-            #   - The left-side join keys survive aggregation (are in GROUP BY)
-            if join_tree_info.join_one_info and not collected_filters:
-                merged_dimensions = _get_merged_fields(all_roots, "dimensions")
-                merged_base_measures = _get_merged_fields(all_roots, "measures")
-                merged_calc_measures = _get_merged_fields(all_roots, "calc_measures")
-                gb_set = frozenset(self.keys)
-                agg_measure_names = frozenset(self.aggs.keys())
-
-                deferrable: list[_DeferrableJoinOne] = []
-                for entry in join_tree_info.join_one_info:
-                    prefix = entry.table_name
-                    # Collect all prefixed dimension names for this table
-                    table_dim_names = frozenset(
-                        k for k in merged_dimensions if k.startswith(f"{prefix}.")
-                    )
-                    # Collect all prefixed measure names for this table
-                    table_measure_names = frozenset(
-                        k for k in merged_base_measures if k.startswith(f"{prefix}.")
-                    )
-                    table_calc_measure_names = frozenset(
-                        k for k in merged_calc_measures if k.startswith(f"{prefix}.")
-                    )
-
-                    # Check if any of this table's fields are used in GROUP BY or aggs
-                    dims_in_gb = table_dim_names & gb_set
-                    measures_in_agg = (
-                        table_measure_names | table_calc_measure_names
-                    ) & agg_measure_names
-
-                    if dims_in_gb or measures_in_agg:
-                        continue  # This table is needed before aggregation
-
-                    # Check that the left-side join keys survive aggregation
-                    # (they must be in the GROUP BY columns)
-                    if not entry.left_join_cols <= gb_set:
-                        continue  # Join keys won't survive aggregation
-
-                    deferrable.append(entry)
-
-                if deferrable:
-                    return self._to_untagged_with_deferred_joins(
-                        all_roots,
-                        join_op,
-                        join_tree_info,
-                        deferrable,
-                    )
+            # Deferred join path: when join_one dimension tables can be
+            # joined AFTER aggregation for better performance.
+            deferrable = _find_deferrable_joins(
+                join_op, self.keys, self.aggs, all_roots, join_tree_info,
+                filters=collected_filters,
+            )
+            if deferrable:
+                return self._to_untagged_with_deferred_joins(
+                    all_roots,
+                    join_op,
+                    join_tree_info,
+                    deferrable,
+                    filters=collected_filters,
+                )
 
         # Only use the join optimization if there are no filters after the join
         # Otherwise we'd skip the filter operations
@@ -2646,169 +2673,190 @@ class SemanticAggregateOp(Relation):
     def _to_untagged_with_deferred_joins(
         self,
         all_roots: list,
-        join_op: SemanticJoinOp,
-        join_tree_info: _JoinTreeInfo,
-        deferrable: list,
+        join_op: "SemanticJoinOp",
+        join_tree_info: "_JoinTreeInfo",
+        deferrable: list["_DeferrableJoin"],
+        filters: list | None = None,
     ):
-        """Aggregate on a reduced join tree, then LEFT JOIN deferred tables.
+        """Aggregate first, then LEFT JOIN deferred dimension tables.
 
-        When a ``join_one`` right-side table's dimensions are only in SELECT
-        (not GROUP BY) and its measures are not aggregated, we can:
-        1. Strip it from the join tree before aggregation
-        2. Aggregate on the smaller tree (fewer GROUP BY columns)
-        3. LEFT JOIN the deferred tables back using the original join keys
+        For ``join_one`` dimension lookups where the right table's PK matches
+        the join key and no measures from the right table are used, we can:
+        1. Strip deferred tables from the join tree
+        2. Add join keys to GROUP BY so they survive aggregation
+        3. Aggregate on the core (non-deferred) tables
+        4. LEFT JOIN deferred dimension tables onto the aggregated result
         """
-        from .convert import _Resolver
+        filters = filters or []
+        deferred_names = {d.table_name for d in deferrable}
 
-        deferred_names = frozenset(d.table_name for d in deferrable)
+        merged_dimensions = _get_merged_fields(all_roots, "dimensions")
+        merged_base_measures = _get_merged_fields(all_roots, "measures")
+        merged_calc_measures = _get_merged_fields(all_roots, "calc_measures")
 
-        # --- 1. Build reduced join tree (strip deferred tables) ---
+        # --- 1. Rebuild join tree without deferred tables ---
         def strip_deferred(node):
-            """Recursively remove deferred right-side tables from the join tree."""
+            """Remove deferred right-side tables from the join tree."""
             if not isinstance(node, SemanticJoinOp):
                 return node
-            # First, recursively strip from left subtree
-            stripped_left = strip_deferred(node.left)
-            # If the right side is a deferred leaf, return the left subtree
+            # Recurse left
+            new_left = strip_deferred(node.left)
+            # If right side is a deferred table, return just the left
             if (
                 isinstance(node.right, SemanticTableOp)
                 and node.right.name in deferred_names
             ):
-                return stripped_left
-            # Otherwise, keep this join with the stripped left
-            stripped_right = strip_deferred(node.right)
+                return new_left
             return SemanticJoinOp(
-                left=stripped_left,
-                right=stripped_right,
+                left=new_left,
+                right=node.right,
                 how=node.how,
                 on=node.on,
                 cardinality=node.cardinality,
             )
 
-        reduced_source = strip_deferred(join_op)
+        core_join = strip_deferred(join_op)
 
-        # --- 2. Build ibis table from the reduced source ---
-        if isinstance(reduced_source, SemanticJoinOp):
-            reduced_tbl = reduced_source.to_untagged(parent_requirements=None)
+        # --- 2. Build core table and aggregate ---
+        if isinstance(core_join, SemanticJoinOp):
+            core_tbl = core_join.to_untagged(parent_requirements=None)
         else:
-            reduced_tbl = _to_untagged(reduced_source)
+            core_tbl = _to_untagged(core_join)
 
-        # --- 3. Compute merged fields from non-deferred roots only ---
-        non_deferred_roots = [
-            r for r in all_roots if r.name not in deferred_names
-        ]
-        merged_dimensions = _get_merged_fields(non_deferred_roots, "dimensions")
-        merged_base_measures = _get_merged_fields(non_deferred_roots, "measures")
-        merged_calc_measures = _get_merged_fields(non_deferred_roots, "calc_measures")
+        # Resolve group-by dimensions on the core table
+        core_group_keys = []
+        for k in self.keys:
+            if k in deferred_names or any(k.startswith(f"{dn}.") for dn in deferred_names):
+                # Skip deferred table's own dimensions from group-by
+                # (they'll be added via post-agg join)
+                continue
+            core_group_keys.append(k)
 
-        # Mutate dimensions needed for GROUP BY onto the reduced table
-        reduced_tbl = _mutate_dimensions_with_dependencies(
-            reduced_tbl,
-            [k for k in self.keys if k in merged_dimensions],
+        # Add left-side join keys to group-by so they survive aggregation
+        for d in deferrable:
+            for jk in d.join_keys_left:
+                if jk not in core_group_keys and jk in core_tbl.columns:
+                    core_group_keys.append(jk)
+
+        # Resolve dimensions for group-by on the core table
+        core_tbl = _mutate_dimensions_with_dependencies(
+            core_tbl,
+            [k for k in core_group_keys if k in merged_dimensions],
             merged_dimensions,
         )
 
-        # --- 4. Build aggregation plan and aggregate ---
+        # Apply filters
+        if filters:
+            from .convert import _Resolver
+
+            for pred in filters:
+                pred_fn = _unwrap(pred)
+                try:
+                    resolver = _Resolver(core_tbl, merged_dimensions)
+                    pred_expr = _resolve_expr(pred_fn, resolver)
+                    core_tbl = core_tbl.filter(pred_expr)
+                except Exception:
+                    pass
+
+        # Build aggregation expressions
         scope = MeasureScope(
-            _tbl=reduced_tbl,
+            _tbl=core_tbl,
             _known=list(merged_base_measures.keys()) + list(merged_calc_measures.keys()),
         )
-
         plan = _build_aggregation_plan(
             aggs=self.aggs,
-            keys=self.keys,
+            keys=tuple(core_group_keys),
             scope=scope,
             is_post_agg=False,
             merged_base_measures=merged_base_measures,
             merged_calc_measures=merged_calc_measures,
-            tbl=reduced_tbl,
+            tbl=core_tbl,
         )
 
-        if plan.calc_specs or plan.group_by_cols:
-            result = compile_grouped_with_all(
-                reduced_tbl,
-                list(plan.group_by_cols),
-                dict(plan.agg_specs),
-                dict(plan.calc_specs),
-                requested_measures=list(plan.requested_measures),
-            )
+        # Execute aggregation on core table
+        if plan.group_by_cols:
+            gb_exprs = []
+            for col in plan.group_by_cols:
+                if col in core_tbl.columns:
+                    gb_exprs.append(core_tbl[col])
+                elif col in merged_dimensions:
+                    dim_fn = merged_dimensions[col]
+                    gb_exprs.append(dim_fn(core_tbl).name(col))
+
+            agg_exprs = {name: fn(core_tbl) for name, fn in plan.agg_specs.items()}
+            result = core_tbl.group_by(gb_exprs).aggregate(**agg_exprs)
         else:
-            result = reduced_tbl.aggregate(
-                {name: fn(reduced_tbl) for name, fn in plan.agg_specs.items()}
-            )
+            agg_exprs = {name: fn(core_tbl) for name, fn in plan.agg_specs.items()}
+            result = core_tbl.aggregate(**agg_exprs)
 
-        # --- 5. LEFT JOIN deferred tables back ---
-        # Collect the full set of deferred dimension names we need to SELECT
-        all_merged_dims = _get_merged_fields(all_roots, "dimensions")
-        deferred_dim_cols = []
-        for entry in deferrable:
-            prefix = entry.table_name
-            for dim_name in all_merged_dims:
-                if dim_name.startswith(f"{prefix}."):
-                    deferred_dim_cols.append(dim_name)
+        # Handle calculated measures
+        if plan.calc_specs:
+            from .compile_all import compile_calc_measures
 
-        for entry in deferrable:
-            # Build the deferred table with its dimensions materialized
-            deferred_tbl = _to_untagged(entry.table_op)
-            deferred_dims = _get_field_dict(entry.table_op, "dimensions")
+            result = compile_calc_measures(result, plan.calc_specs)
 
-            # Determine which dimensions from this deferred table we need
-            prefix = entry.table_name
-            needed_dims = [
-                d for d in deferred_dim_cols if d.startswith(f"{prefix}.")
+        # --- 3. LEFT JOIN deferred dimension tables ---
+        for d in deferrable:
+            dim_tbl = _to_untagged(d.table_op)
+
+            # Build join predicate: result.left_key == dim_tbl.right_key
+            join_preds = [
+                result[lk] == dim_tbl[rk]
+                for lk, rk in zip(d.join_keys_left, d.join_keys_right)
             ]
 
-            # Mutate dimensions onto the deferred table
-            if needed_dims:
-                deferred_tbl = _mutate_dimensions_with_dependencies(
-                    deferred_tbl,
-                    needed_dims,
-                    all_merged_dims,
-                )
+            # Compute deferred dimension columns on the dimension table.
+            # For direct columns (e.g., cc_name) this is a no-op rename.
+            # For derived expressions (e.g., cc_name.upper()) this materializes
+            # the computed column so it's available after the join.
+            dim_cols_to_add = []
+            right_dims = d.table_op.get_dimensions()
+            for dim_name in d.deferred_dims:
+                short = dim_name.split(".", 1)[1] if "." in dim_name else dim_name
+                if short in right_dims:
+                    dim_fn = right_dims[short]
+                    if callable(dim_fn):
+                        try:
+                            expr = dim_fn(dim_tbl)
+                            col_name = expr.get_name()
+                            if col_name in dim_tbl.columns:
+                                # Direct column — use as-is
+                                dim_cols_to_add.append((dim_name, col_name))
+                            else:
+                                # Derived expression — mutate onto dim table
+                                # Use a temp name to avoid collisions
+                                temp_name = f"__deferred_{short}"
+                                dim_tbl = dim_tbl.mutate(**{temp_name: expr})
+                                dim_cols_to_add.append((dim_name, temp_name))
+                        except Exception:
+                            pass
 
-            # Build join predicate using the original on function
-            # The left_join_cols are the aggregated result's columns (GROUP BY keys)
-            # The right_join_cols are the deferred table's columns
-            left_keys = sorted(entry.left_join_cols)
-            right_keys = sorted(entry.right_join_cols)
+            if dim_cols_to_add:
+                # Perform the LEFT JOIN
+                joined = result.left_join(dim_tbl, join_preds)
+                # Select: all from result + deferred dim columns renamed to prefixed names
+                select_exprs = [result]
+                for prefixed_name, raw_col in dim_cols_to_add:
+                    select_exprs.append(dim_tbl[raw_col].name(prefixed_name))
+                result = joined.select(select_exprs)
 
-            if not left_keys or not right_keys:
-                continue
+        # --- 4. Select only originally requested columns ---
+        original_cols = list(self.keys) + list(self.aggs.keys())
+        # Add deferred dim names (they were requested)
+        for d in deferrable:
+            for dd in d.deferred_dims:
+                if dd not in original_cols:
+                    original_cols.append(dd)
+        # Also keep calc measure names
+        if plan.calc_specs:
+            for cm in plan.calc_specs:
+                if cm not in original_cols:
+                    original_cols.append(cm)
 
-            # Select only the columns we need from the deferred table:
-            # join keys + needed dimensions
-            deferred_select_cols = []
-            for col in right_keys:
-                if col in deferred_tbl.columns:
-                    deferred_select_cols.append(col)
-            for dim_name in needed_dims:
-                if dim_name in deferred_tbl.columns:
-                    deferred_select_cols.append(dim_name)
-
-            if not deferred_select_cols:
-                continue
-
-            # Deduplicate while preserving order
-            deferred_select_cols = list(dict.fromkeys(deferred_select_cols))
-            deferred_bridge = deferred_tbl.select(
-                [deferred_tbl[c] for c in deferred_select_cols]
-            ).distinct()
-
-            # Build join predicates
-            preds = [
-                result[lk] == deferred_bridge[rk]
-                for lk, rk in zip(left_keys, right_keys)
-            ]
-
-            # Select: all from result + new dimension columns from deferred
-            new_cols = [
-                c for c in deferred_select_cols
-                if c not in frozenset(right_keys) and c not in result.columns
-            ]
-
-            result = result.left_join(deferred_bridge, preds).select(
-                [result] + [deferred_bridge[c] for c in new_cols]
-            )
+        available = frozenset(result.columns)
+        select_cols = [c for c in original_cols if c in available]
+        if select_cols and set(select_cols) != available:
+            result = result.select([result[c] for c in select_cols])
 
         return result
 

--- a/src/boring_semantic_layer/serialization/extract.py
+++ b/src/boring_semantic_layer/serialization/extract.py
@@ -175,7 +175,7 @@ def _extract_limit(op, context: BSLSerializationContext) -> dict[str, Any]:
 def _extract_join(op, context: BSLSerializationContext) -> dict[str, Any]:
     from ..utils import join_predicate_to_structured
 
-    metadata: dict[str, Any] = {"how": op.how}
+    metadata: dict[str, Any] = {"how": op.how, "cardinality": op.cardinality}
     if op.on is not None:
         struct_result = join_predicate_to_structured(op.on)
         match struct_result:

--- a/src/boring_semantic_layer/serialization/reconstruct.py
+++ b/src/boring_semantic_layer/serialization/reconstruct.py
@@ -261,6 +261,7 @@ def _reconstruct_join(
     right_model = reconstruct_bsl_operation(right_metadata, right_xorq_expr, context)
 
     how = metadata.get("how", "inner")
+    cardinality = metadata.get("cardinality", "one")
     on_struct = metadata.get("on_struct")
 
     if on_struct is None:
@@ -269,10 +270,18 @@ def _reconstruct_join(
             right=right_model.op() if hasattr(right_model, "op") else right_model,
             on=None,
             how=how,
+            cardinality=cardinality,
         )
 
     predicate = context.deserialize_join_predicate(on_struct)
-    return left_model.join_many(right_model, on=predicate, how=how)
+    join_method = {
+        "one": "join_one",
+        "many": "join_many",
+        "cross": "join_cross",
+    }.get(cardinality, "join_many")
+    if join_method == "join_cross":
+        return left_model.join_cross(right_model)
+    return getattr(left_model, join_method)(right_model, on=predicate, how=how)
 
 
 # ---------------------------------------------------------------------------

--- a/src/boring_semantic_layer/tests/test_deferred_join.py
+++ b/src/boring_semantic_layer/tests/test_deferred_join.py
@@ -1,0 +1,228 @@
+"""Tests for deferred join_one — dimension lookups joined after aggregation.
+
+When a join_one dimension table's PK matches the join key and no measures
+from that table are used, BSL defers the join until after aggregation for
+better performance. Results must match the non-deferred path exactly.
+"""
+
+import ibis
+import pandas as pd
+import pytest
+
+from boring_semantic_layer import Dimension, to_semantic_table
+
+
+@pytest.fixture(scope="module")
+def con():
+    return ibis.duckdb.connect(":memory:")
+
+
+@pytest.fixture(scope="module")
+def lookup_tables(con):
+    """Users fact table + cost_centers dimension table."""
+    users_df = pd.DataFrame(
+        {
+            "user_id": [1, 1, 2, 2, 3],
+            "cost_center_id": [101, 101, 102, 102, 101],
+            "login_date": pd.to_datetime(
+                ["2024-01-01", "2024-01-02", "2024-01-01", "2024-01-03", "2024-01-01"]
+            ),
+        }
+    )
+    cost_centers_df = pd.DataFrame(
+        {
+            "cc_id": [101, 102],
+            "cc_name": ["Engineering", "Marketing"],
+            "location": ["NYC", "SF"],
+        }
+    )
+    return {
+        "users": con.create_table("users", users_df),
+        "cost_centers": con.create_table("cost_centers", cost_centers_df),
+    }
+
+
+def _make_users_model(tbl):
+    return (
+        to_semantic_table(tbl, name="users")
+        .with_dimensions(
+            user_id=Dimension(expr=lambda t: t.user_id, is_entity=True),
+            cost_center_id=lambda t: t.cost_center_id,
+        )
+        .with_measures(login_count=lambda t: t.count())
+    )
+
+
+def _make_cost_centers_model(tbl):
+    return (
+        to_semantic_table(tbl, name="cost_centers")
+        .with_dimensions(
+            cc_id=Dimension(expr=lambda t: t.cc_id, is_entity=True),
+            cc_name=lambda t: t.cc_name,
+            location=lambda t: t.location,
+        )
+    )
+
+
+class TestDeferredJoinDetection:
+    """Test that deferrable joins are correctly identified."""
+
+    def test_dimension_table_with_pk_is_deferrable(self, lookup_tables):
+        """join_one to a dimension table with is_entity PK matching join key is deferrable."""
+        users = _make_users_model(lookup_tables["users"])
+        cc = _make_cost_centers_model(lookup_tables["cost_centers"])
+
+        joined = users.join_one(
+            cc, on=lambda u, c: u.cost_center_id == c.cc_id
+        )
+
+        # Query only user measures — cost_centers should be deferred
+        result = (
+            joined.group_by("users.user_id")
+            .aggregate("users.login_count")
+            .execute()
+            .sort_values("users.user_id")
+            .reset_index(drop=True)
+        )
+
+        # user 1: 2 logins, user 2: 2 logins, user 3: 1 login
+        assert list(result["users.user_id"]) == [1, 2, 3]
+        assert list(result["users.login_count"]) == [2, 2, 1]
+
+    def test_no_deferral_without_entity(self, lookup_tables):
+        """No deferral when dimension table has no is_entity dims."""
+        users = _make_users_model(lookup_tables["users"])
+        cc_no_pk = (
+            to_semantic_table(lookup_tables["cost_centers"], name="cost_centers")
+            .with_dimensions(
+                cc_id=lambda t: t.cc_id,  # NOT is_entity
+                cc_name=lambda t: t.cc_name,
+            )
+        )
+
+        joined = users.join_one(
+            cc_no_pk, on=lambda u, c: u.cost_center_id == c.cc_id
+        )
+
+        # Should still work via standard path
+        result = (
+            joined.group_by("users.user_id")
+            .aggregate("users.login_count")
+            .execute()
+            .sort_values("users.user_id")
+            .reset_index(drop=True)
+        )
+        assert list(result["users.login_count"]) == [2, 2, 1]
+
+
+class TestDeferredJoinWithDimensions:
+    """Test that deferred dimensions are correctly added post-aggregation."""
+
+    def test_deferred_dim_added_post_agg(self, lookup_tables):
+        """Deferred dimension columns appear in the result via post-agg join."""
+        users = _make_users_model(lookup_tables["users"])
+        cc = _make_cost_centers_model(lookup_tables["cost_centers"])
+
+        joined = users.join_one(
+            cc, on=lambda u, c: u.cost_center_id == c.cc_id
+        )
+
+        # Include cost_center dims in group-by — should be deferred
+        result = (
+            joined.group_by("users.user_id", "cost_centers.cc_name")
+            .aggregate("users.login_count")
+            .execute()
+            .sort_values("users.user_id")
+            .reset_index(drop=True)
+        )
+
+        assert list(result["users.user_id"]) == [1, 2, 3]
+        assert list(result["cost_centers.cc_name"]) == [
+            "Engineering",
+            "Marketing",
+            "Engineering",
+        ]
+        assert list(result["users.login_count"]) == [2, 2, 1]
+
+    def test_multiple_deferred_dims(self, lookup_tables):
+        """Multiple dimensions from the deferred table are all added."""
+        users = _make_users_model(lookup_tables["users"])
+        cc = _make_cost_centers_model(lookup_tables["cost_centers"])
+
+        joined = users.join_one(
+            cc, on=lambda u, c: u.cost_center_id == c.cc_id
+        )
+
+        result = (
+            joined.group_by(
+                "users.user_id", "cost_centers.cc_name", "cost_centers.location"
+            )
+            .aggregate("users.login_count")
+            .execute()
+            .sort_values("users.user_id")
+            .reset_index(drop=True)
+        )
+
+        assert list(result["cost_centers.cc_name"]) == [
+            "Engineering",
+            "Marketing",
+            "Engineering",
+        ]
+        assert list(result["cost_centers.location"]) == ["NYC", "SF", "NYC"]
+
+
+class TestDeferredJoinCorrectness:
+    """Verify deferred join results match standard (non-deferred) path."""
+
+    def test_results_match_standard_path(self, lookup_tables):
+        """Deferred join produces identical results to the standard join path."""
+        users = _make_users_model(lookup_tables["users"])
+
+        # Deferred path: cost_centers WITH is_entity PK
+        cc_with_pk = _make_cost_centers_model(lookup_tables["cost_centers"])
+        joined_deferred = users.join_one(
+            cc_with_pk, on=lambda u, c: u.cost_center_id == c.cc_id
+        )
+
+        # Standard path: cost_centers WITHOUT is_entity → no deferral
+        cc_no_pk = (
+            to_semantic_table(lookup_tables["cost_centers"], name="cost_centers")
+            .with_dimensions(
+                cc_id=lambda t: t.cc_id,
+                cc_name=lambda t: t.cc_name,
+            )
+        )
+        joined_standard = users.join_one(
+            cc_no_pk, on=lambda u, c: u.cost_center_id == c.cc_id
+        )
+
+        # Both should produce the same result
+        result_deferred = (
+            joined_deferred.group_by("users.user_id", "cost_centers.cc_name")
+            .aggregate("users.login_count")
+            .execute()
+            .sort_values("users.user_id")
+            .reset_index(drop=True)
+        )
+
+        result_standard = (
+            joined_standard.group_by("users.user_id", "cost_centers.cc_name")
+            .aggregate("users.login_count")
+            .execute()
+            .sort_values("users.user_id")
+            .reset_index(drop=True)
+        )
+
+        pd.testing.assert_frame_equal(result_deferred, result_standard)
+
+    def test_scalar_aggregate_with_deferred(self, lookup_tables):
+        """Scalar aggregate (no group-by) works with deferred joins."""
+        users = _make_users_model(lookup_tables["users"])
+        cc = _make_cost_centers_model(lookup_tables["cost_centers"])
+
+        joined = users.join_one(
+            cc, on=lambda u, c: u.cost_center_id == c.cc_id
+        )
+
+        result = joined.aggregate("users.login_count").execute()
+        assert result["users.login_count"].iloc[0] == 5

--- a/src/boring_semantic_layer/tests/test_deferred_join.py
+++ b/src/boring_semantic_layer/tests/test_deferred_join.py
@@ -250,3 +250,73 @@ class TestDeferredJoinCorrectness:
         assert list(result["users.user_id"]) == [1, 3]
         assert list(result["users.login_count"]) == [2, 1]
         assert list(result["cost_centers.cc_name"]) == ["Engineering", "Engineering"]
+
+
+class TestJoinCardinalitySerialization:
+    """Test that join cardinality is included in hashing_tag metadata."""
+
+    def test_cardinality_in_join_metadata(self, lookup_tables):
+        """Cardinality is serialized so join_one and join_many get different hashes."""
+        from boring_semantic_layer.serialization.extract import extract_op_tree
+        from boring_semantic_layer.serialization.context import BSLSerializationContext
+
+        users = _make_users_model(lookup_tables["users"])
+        cc = _make_cost_centers_model(lookup_tables["cost_centers"])
+
+        joined = users.join_one(
+            cc, on=lambda u, c: u.cost_center_id == c.cc_id
+        )
+
+        ctx = BSLSerializationContext()
+        agg_op = joined.group_by("users.user_id").aggregate("users.login_count").op()
+        metadata = extract_op_tree(agg_op, ctx)
+
+        # Walk to find the join metadata
+        def find_cardinality(d):
+            if isinstance(d, dict):
+                if "cardinality" in d:
+                    return d["cardinality"]
+                for v in d.values():
+                    result = find_cardinality(v)
+                    if result is not None:
+                        return result
+            return None
+
+        cardinality = find_cardinality(metadata)
+        assert cardinality == "one"
+
+    def test_join_many_cardinality_serialized(self, lookup_tables):
+        """join_many cardinality is serialized as 'many'."""
+        from boring_semantic_layer.serialization.extract import extract_op_tree
+        from boring_semantic_layer.serialization.context import BSLSerializationContext
+
+        users = _make_users_model(lookup_tables["users"])
+        cc_with_measures = (
+            to_semantic_table(lookup_tables["cost_centers"], name="cost_centers")
+            .with_dimensions(
+                cc_id=Dimension(expr=lambda t: t.cc_id, is_entity=True),
+                cc_name=lambda t: t.cc_name,
+            )
+            .with_measures(cc_count=lambda t: t.count())
+        )
+
+        joined = users.join_many(
+            cc_with_measures, on=lambda u, c: u.cost_center_id == c.cc_id
+        )
+
+        ctx = BSLSerializationContext()
+        agg_op = joined.group_by("users.user_id").aggregate("users.login_count").op()
+        metadata = extract_op_tree(agg_op, ctx)
+
+        def find_cardinality(d):
+            if isinstance(d, dict):
+                if "cardinality" in d:
+                    return d["cardinality"]
+                for v in d.values():
+                    result = find_cardinality(v)
+                    if result is not None:
+                        return result
+            return None
+
+        cardinality = find_cardinality(metadata)
+        assert cardinality == "many"

--- a/src/boring_semantic_layer/tests/test_deferred_join.py
+++ b/src/boring_semantic_layer/tests/test_deferred_join.py
@@ -226,3 +226,27 @@ class TestDeferredJoinCorrectness:
 
         result = joined.aggregate("users.login_count").execute()
         assert result["users.login_count"].iloc[0] == 5
+
+    def test_no_deferral_when_filter_on_deferred_table(self, lookup_tables):
+        """Joins must NOT be deferred if a filter references the dimension table."""
+        users = _make_users_model(lookup_tables["users"])
+        cc = _make_cost_centers_model(lookup_tables["cost_centers"])
+
+        joined = users.join_one(
+            cc, on=lambda u, c: u.cost_center_id == c.cc_id
+        )
+
+        # Filter on the dimension table's column — must not defer
+        result = (
+            joined.filter(lambda t: t.cc_name == "Engineering")
+            .group_by("users.user_id", "cost_centers.cc_name")
+            .aggregate("users.login_count")
+            .execute()
+            .sort_values("users.user_id")
+            .reset_index(drop=True)
+        )
+
+        # Only Engineering users: user_id 1 (2 logins) and user_id 3 (1 login)
+        assert list(result["users.user_id"]) == [1, 3]
+        assert list(result["users.login_count"]) == [2, 1]
+        assert list(result["cost_centers.cc_name"]) == ["Engineering", "Engineering"]

--- a/src/boring_semantic_layer/tests/test_deferred_join.py
+++ b/src/boring_semantic_layer/tests/test_deferred_join.py
@@ -320,3 +320,204 @@ class TestJoinCardinalitySerialization:
 
         cardinality = find_cardinality(metadata)
         assert cardinality == "many"
+
+
+# ---------------------------------------------------------------------------
+# Edge case tests surfaced by external reviewers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def snowflake_tables(con):
+    """Snowflake schema: orders → regions → countries (chained join_one)."""
+    orders_df = pd.DataFrame(
+        {
+            "order_id": [1, 2, 3, 4, 5],
+            "region_id": [10, 20, 10, 20, 10],
+            "amount": [100.0, 200.0, 150.0, 300.0, 250.0],
+        }
+    )
+    regions_df = pd.DataFrame(
+        {
+            "region_id": [10, 20],
+            "region_name": ["West", "East"],
+            "country_id": [1, 1],
+        }
+    )
+    countries_df = pd.DataFrame(
+        {
+            "country_id": [1],
+            "country_name": ["USA"],
+        }
+    )
+    return {
+        "orders": con.create_table("orders_sf", orders_df),
+        "regions": con.create_table("regions_sf", regions_df),
+        "countries": con.create_table("countries_sf", countries_df),
+    }
+
+
+class TestSnowflakeChainedJoinOne:
+    """Edge case: chained join_one in a snowflake schema."""
+
+    def test_snowflake_two_dim_lookups(self, snowflake_tables):
+        """orders → regions → countries: both dimension tables deferred correctly."""
+        orders = (
+            to_semantic_table(snowflake_tables["orders"], name="orders")
+            .with_dimensions(
+                order_id=Dimension(expr=lambda t: t.order_id, is_entity=True),
+                region_id=lambda t: t.region_id,
+            )
+            .with_measures(total_amount=lambda t: t.amount.sum())
+        )
+        regions = (
+            to_semantic_table(snowflake_tables["regions"], name="regions")
+            .with_dimensions(
+                region_id=Dimension(expr=lambda t: t.region_id, is_entity=True),
+                region_name=lambda t: t.region_name,
+                country_id=lambda t: t.country_id,
+            )
+        )
+        countries = (
+            to_semantic_table(snowflake_tables["countries"], name="countries")
+            .with_dimensions(
+                country_id=Dimension(expr=lambda t: t.country_id, is_entity=True),
+                country_name=lambda t: t.country_name,
+            )
+        )
+
+        joined = orders.join_one(
+            regions, on=lambda o, r: o.region_id == r.region_id
+        ).join_one(
+            countries, on=lambda j, c: j.country_id == c.country_id
+        )
+
+        result = (
+            joined.group_by("regions.region_name")
+            .aggregate("orders.total_amount")
+            .execute()
+            .sort_values("regions.region_name")
+            .reset_index(drop=True)
+        )
+
+        assert list(result["regions.region_name"]) == ["East", "West"]
+        assert list(result["orders.total_amount"]) == [500.0, 500.0]
+
+    def test_snowflake_results_match_standard(self, snowflake_tables):
+        """Snowflake deferred results match the standard (non-deferred) path."""
+        orders = (
+            to_semantic_table(snowflake_tables["orders"], name="orders")
+            .with_dimensions(
+                order_id=Dimension(expr=lambda t: t.order_id, is_entity=True),
+                region_id=lambda t: t.region_id,
+            )
+            .with_measures(total_amount=lambda t: t.amount.sum())
+        )
+
+        # Deferred: regions WITH is_entity
+        regions_deferred = (
+            to_semantic_table(snowflake_tables["regions"], name="regions")
+            .with_dimensions(
+                region_id=Dimension(expr=lambda t: t.region_id, is_entity=True),
+                region_name=lambda t: t.region_name,
+            )
+        )
+        # Standard: regions WITHOUT is_entity
+        regions_standard = (
+            to_semantic_table(snowflake_tables["regions"], name="regions")
+            .with_dimensions(
+                region_id=lambda t: t.region_id,
+                region_name=lambda t: t.region_name,
+            )
+        )
+
+        joined_deferred = orders.join_one(
+            regions_deferred, on=lambda o, r: o.region_id == r.region_id
+        )
+        joined_standard = orders.join_one(
+            regions_standard, on=lambda o, r: o.region_id == r.region_id
+        )
+
+        result_d = (
+            joined_deferred.group_by("regions.region_name")
+            .aggregate("orders.total_amount")
+            .execute()
+            .sort_values("regions.region_name")
+            .reset_index(drop=True)
+        )
+        result_s = (
+            joined_standard.group_by("regions.region_name")
+            .aggregate("orders.total_amount")
+            .execute()
+            .sort_values("regions.region_name")
+            .reset_index(drop=True)
+        )
+
+        pd.testing.assert_frame_equal(result_d, result_s)
+
+
+class TestDerivedDimensions:
+    """Edge case: deferred dimension is a derived expression, not a direct column."""
+
+    def test_derived_dim_on_deferred_table(self, lookup_tables):
+        """Derived dimension (e.g., upper()) on a deferred table falls back gracefully."""
+        users = _make_users_model(lookup_tables["users"])
+
+        # Dimension with a derived expression
+        cc_derived = (
+            to_semantic_table(lookup_tables["cost_centers"], name="cost_centers")
+            .with_dimensions(
+                cc_id=Dimension(expr=lambda t: t.cc_id, is_entity=True),
+                cc_name_upper=lambda t: t.cc_name.upper(),
+            )
+        )
+
+        joined = users.join_one(
+            cc_derived, on=lambda u, c: u.cost_center_id == c.cc_id
+        )
+
+        # This should still produce correct results — either via deferred path
+        # (if the derived dim resolves) or via standard fallback
+        result = (
+            joined.group_by("users.user_id", "cost_centers.cc_name_upper")
+            .aggregate("users.login_count")
+            .execute()
+            .sort_values("users.user_id")
+            .reset_index(drop=True)
+        )
+
+        assert list(result["users.user_id"]) == [1, 2, 3]
+        assert list(result["users.login_count"]) == [2, 2, 1]
+        # Derived dim should have uppercase values
+        assert list(result["cost_centers.cc_name_upper"]) == [
+            "ENGINEERING",
+            "MARKETING",
+            "ENGINEERING",
+        ]
+
+
+class TestPrefixedFilterOnDeferredTable:
+    """Edge case: filter uses prefixed dimension name from deferred table."""
+
+    def test_prefixed_filter_prevents_deferral(self, lookup_tables):
+        """Filter using table.dimension syntax on deferred table still works."""
+        users = _make_users_model(lookup_tables["users"])
+        cc = _make_cost_centers_model(lookup_tables["cost_centers"])
+
+        joined = users.join_one(
+            cc, on=lambda u, c: u.cost_center_id == c.cc_id
+        )
+
+        # Filter on location (from deferred table) — should fall back to standard path
+        result = (
+            joined.filter(lambda t: t.location == "NYC")
+            .group_by("users.user_id", "cost_centers.cc_name")
+            .aggregate("users.login_count")
+            .execute()
+            .sort_values("users.user_id")
+            .reset_index(drop=True)
+        )
+
+        # Only NYC cost center (101 = Engineering): user 1 (2 logins), user 3 (1 login)
+        assert list(result["users.user_id"]) == [1, 3]
+        assert list(result["users.login_count"]) == [2, 1]

--- a/src/boring_semantic_layer/tests/test_grain.py
+++ b/src/boring_semantic_layer/tests/test_grain.py
@@ -1,0 +1,205 @@
+"""Tests for grain-aware join_one using is_entity dimensions.
+
+When both models declare is_entity dimensions and their entity sets differ,
+join_one auto-upgrades to join_many so BSL's pre-aggregation logic aligns
+the grains before joining — preventing fan-out / double-counting.
+"""
+
+import warnings
+
+import ibis
+import pandas as pd
+import pytest
+
+from boring_semantic_layer import Dimension, to_semantic_table
+
+
+@pytest.fixture(scope="module")
+def con():
+    return ibis.duckdb.connect(":memory:")
+
+
+@pytest.fixture(scope="module")
+def multi_fact_tables(con):
+    """Monthly financials + daily hours — classic multi-fact grain mismatch."""
+    financials_df = pd.DataFrame(
+        {
+            "year": [2024, 2024, 2024],
+            "month": [1, 2, 3],
+            "revenue": [10000.0, 12000.0, 11000.0],
+        }
+    )
+    hours_df = pd.DataFrame(
+        {
+            "year": [2024, 2024, 2024, 2024, 2024, 2024],
+            "month": [1, 1, 2, 2, 3, 3],
+            "day": [1, 15, 1, 15, 1, 15],
+            "hours_worked": [80.0, 85.0, 90.0, 75.0, 88.0, 82.0],
+        }
+    )
+    return {
+        "financials": con.create_table("financials", financials_df),
+        "hours": con.create_table("hours", hours_df),
+    }
+
+
+def _make_financials_model(tbl):
+    return (
+        to_semantic_table(tbl, name="financials")
+        .with_dimensions(
+            year=Dimension(expr=lambda t: t.year, is_entity=True),
+            month=Dimension(expr=lambda t: t.month, is_entity=True),
+        )
+        .with_measures(total_revenue=lambda t: t.revenue.sum())
+    )
+
+
+def _make_hours_model(tbl):
+    return (
+        to_semantic_table(tbl, name="hours")
+        .with_dimensions(
+            year=Dimension(expr=lambda t: t.year, is_entity=True),
+            month=Dimension(expr=lambda t: t.month, is_entity=True),
+            day=Dimension(expr=lambda t: t.day, is_entity=True),
+        )
+        .with_measures(total_hours=lambda t: t.hours_worked.sum())
+    )
+
+
+class TestGrainMismatchDetection:
+    """Test that join_one detects grain mismatch via is_entity dims."""
+
+    def test_different_entity_dims_upgrades_to_many(self, multi_fact_tables):
+        """join_one auto-upgrades to join_many when entity sets differ."""
+        fin = _make_financials_model(multi_fact_tables["financials"])
+        hrs = _make_hours_model(multi_fact_tables["hours"])
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            joined = fin.join_one(
+                hrs, on=lambda f, h: (f.year == h.year) & (f.month == h.month)
+            )
+            assert len(w) == 1
+            assert "Grain mismatch" in str(w[0].message)
+            assert "join_many" in str(w[0].message)
+
+        # Verify the join has cardinality="many" internally
+        assert joined.op().cardinality == "many"
+
+    def test_same_entity_dims_stays_one(self, multi_fact_tables):
+        """join_one stays join_one when both sides have the same entity dims."""
+        fin = _make_financials_model(multi_fact_tables["financials"])
+
+        # Create another model with same grain (year, month)
+        other = (
+            to_semantic_table(multi_fact_tables["hours"], name="hours_agg")
+            .with_dimensions(
+                year=Dimension(expr=lambda t: t.year, is_entity=True),
+                month=Dimension(expr=lambda t: t.month, is_entity=True),
+            )
+            .with_measures(total_hours=lambda t: t.hours_worked.sum())
+        )
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            joined = fin.join_one(
+                other, on=lambda f, h: (f.year == h.year) & (f.month == h.month)
+            )
+            grain_warnings = [x for x in w if "Grain mismatch" in str(x.message)]
+            assert len(grain_warnings) == 0
+
+        assert joined.op().cardinality == "one"
+
+    def test_no_entity_dims_stays_one(self, multi_fact_tables):
+        """join_one stays join_one when neither side has entity dims (backward compat)."""
+        fin = (
+            to_semantic_table(multi_fact_tables["financials"], name="financials")
+            .with_dimensions(
+                year=lambda t: t.year,
+                month=lambda t: t.month,
+            )
+            .with_measures(total_revenue=lambda t: t.revenue.sum())
+        )
+        hrs = (
+            to_semantic_table(multi_fact_tables["hours"], name="hours")
+            .with_dimensions(
+                year=lambda t: t.year,
+                month=lambda t: t.month,
+                day=lambda t: t.day,
+            )
+            .with_measures(total_hours=lambda t: t.hours_worked.sum())
+        )
+
+        joined = fin.join_one(
+            hrs, on=lambda f, h: (f.year == h.year) & (f.month == h.month)
+        )
+        assert joined.op().cardinality == "one"
+
+    def test_one_side_has_entities_other_doesnt_stays_one(self, multi_fact_tables):
+        """join_one stays join_one when only one side has entity dims."""
+        fin = _make_financials_model(multi_fact_tables["financials"])
+        hrs = (
+            to_semantic_table(multi_fact_tables["hours"], name="hours")
+            .with_dimensions(
+                year=lambda t: t.year,
+                month=lambda t: t.month,
+                day=lambda t: t.day,
+            )
+            .with_measures(total_hours=lambda t: t.hours_worked.sum())
+        )
+
+        joined = fin.join_one(
+            hrs, on=lambda f, h: (f.year == h.year) & (f.month == h.month)
+        )
+        assert joined.op().cardinality == "one"
+
+
+class TestGrainAwareQueryResults:
+    """Test that grain-aware joins produce correct aggregated results."""
+
+    def test_multi_fact_no_fanout(self, multi_fact_tables):
+        """Monthly revenue + daily hours: no fan-out, correct totals per month."""
+        fin = _make_financials_model(multi_fact_tables["financials"])
+        hrs = _make_hours_model(multi_fact_tables["hours"])
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            combined = fin.join_one(
+                hrs, on=lambda f, h: (f.year == h.year) & (f.month == h.month)
+            )
+
+        result = (
+            combined.group_by("financials.month")
+            .aggregate("financials.total_revenue", "hours.total_hours")
+            .execute()
+            .sort_values("financials.month")
+            .reset_index(drop=True)
+        )
+
+        # Revenue should NOT be multiplied by number of days
+        # financials has 3 months: 10000, 12000, 11000
+        assert list(result["financials.total_revenue"]) == [10000.0, 12000.0, 11000.0]
+
+        # Hours should be correctly summed per month
+        # month 1: 80+85=165, month 2: 90+75=165, month 3: 88+82=170
+        assert list(result["hours.total_hours"]) == [165.0, 165.0, 170.0]
+
+    def test_multi_fact_scalar_aggregate(self, multi_fact_tables):
+        """Total revenue + total hours across all months — no group by."""
+        fin = _make_financials_model(multi_fact_tables["financials"])
+        hrs = _make_hours_model(multi_fact_tables["hours"])
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            combined = fin.join_one(
+                hrs, on=lambda f, h: (f.year == h.year) & (f.month == h.month)
+            )
+
+        result = combined.aggregate(
+            "financials.total_revenue", "hours.total_hours"
+        ).execute()
+
+        # Total revenue: 10000 + 12000 + 11000 = 33000
+        assert result["financials.total_revenue"].iloc[0] == 33000.0
+        # Total hours: 80+85+90+75+88+82 = 500
+        assert result["hours.total_hours"].iloc[0] == 500.0


### PR DESCRIPTION
## Summary

Closes #64
Depends on: #219 (grain-aware join_one via is_entity)

When a `join_one` dimension table's PK (`is_entity`) matches the join key and no measures from that table are used, BSL now **defers the join until after aggregation**. This avoids unnecessary join expansion before GROUP BY for pure dimension lookups.

Also refines the grain mismatch detection from #219: pure dimension tables (no measures) stay as `join_one` and use the deferred path, rather than being upgraded to `join_many`.

## Design

Addresses the approach proposed by @hachej and @jklaise: `is_entity` as the primary key concept enables BSL to know which joins are safe to defer.

**A join is deferrable when:**
1. Cardinality is `"one"` (join_one)
2. Right table has `is_entity` dims matching the join key (PK = join key)
3. No measures from right table are used in the aggregation
4. Group-by dimensions from right table exist (something to defer)

**Current SQL** (join before aggregation):
```sql
SELECT users.user_id, cost_centers.name, COUNT(*)
FROM users
JOIN cost_centers ON users.cc_id = cost_centers.id
GROUP BY users.user_id, cost_centers.name
```

**Deferred SQL** (aggregate first, then join):
```sql
SELECT agg.user_id, cc.name, agg.login_count
FROM (
  SELECT user_id, cc_id, COUNT(*) as login_count
  FROM users
  GROUP BY user_id, cc_id
) agg
LEFT JOIN cost_centers cc ON agg.cc_id = cc.id
```

## Example

```python
from boring_semantic_layer import Dimension, to_semantic_table

users = (
    to_semantic_table(users_tbl, name="users")
    .with_dimensions(
        user_id=Dimension(expr=lambda t: t.user_id, is_entity=True),
        cost_center_id=lambda t: t.cost_center_id,
    )
    .with_measures(login_count=lambda t: t.count())
)

cost_centers = (
    to_semantic_table(cc_tbl, name="cost_centers")
    .with_dimensions(
        cc_id=Dimension(expr=lambda t: t.cc_id, is_entity=True),
        cc_name=lambda t: t.cc_name,
        location=lambda t: t.location,
    )
    # No measures — pure dimension table
)

joined = users.join_one(cost_centers, on=lambda u, c: u.cost_center_id == c.cc_id)

# BSL defers the join: aggregates users first, then LEFT JOINs cost_centers
result = joined.group_by("users.user_id", "cost_centers.cc_name").aggregate(
    "users.login_count"
).execute()
```

## Test plan

- [x] Dimension table with PK is deferrable
- [x] No deferral without is_entity
- [x] Deferred dims added correctly post-agg
- [x] Multiple deferred dims from same table
- [x] Results match standard (non-deferred) path exactly
- [x] Scalar aggregate with deferred joins
- [x] Grain tests still pass (6/6)
- [x] Existing test suite: 434 passed (1 pre-existing MCP failure unrelated)

Generated with [Claude Code](https://claude.com/claude-code)