### PR TITLE
fix: preserve join cardinality on round-trip, fix pre-agg grain for derived dims

### DIFF
--- a/src/boring_semantic_layer/ops.py
+++ b/src/boring_semantic_layer/ops.py
@@ -2575,9 +2575,18 @@ class SemanticAggregateOp(Relation):
                     if prefix == table_name and short in table_dims:
                         dim_fn = table_dims[short]
                         if callable(dim_fn):
-                            col_name = dim_fn(raw_tbl).get_name()
-                            if col_name in raw_columns and col_name not in _local_dims:
-                                _local_dims.append(col_name)
+                            dim_expr = dim_fn(raw_tbl)
+                            col_name = dim_expr.get_name()
+                            if col_name == short and col_name in raw_columns:
+                                # Simple column reference — use directly
+                                if col_name not in _local_dims:
+                                    _local_dims.append(col_name)
+                            elif col_name in raw_columns or short not in raw_columns:
+                                # Derived dimension — materialize on raw_tbl
+                                raw_tbl = raw_tbl.mutate(**{short: dim_expr})
+                                raw_columns = set(raw_tbl.columns)
+                                if short not in _local_dims:
+                                    _local_dims.append(short)
                     elif prefix != table_name:
                         has_cross_table_gb = True
 

--- a/src/boring_semantic_layer/tests/test_xorq_string_serialization.py
+++ b/src/boring_semantic_layer/tests/test_xorq_string_serialization.py
@@ -1696,6 +1696,99 @@ def test_tagged_roundtrip_join_derived_dimension_on_root():
     assert list(result["flights_dd.flight_count"]) == list(baseline["flights_dd.flight_count"])
 
 
+def test_tagged_roundtrip_join_one_preserves_cardinality():
+    """join_one cardinality survives to_tagged → from_tagged round-trip.
+
+    Regression: _reconstruct_join always used join_many, changing cardinality
+    from "one" to "many". This caused the aggregate to take the pre-agg path
+    which computed wrong grain for derived dimensions.
+    """
+    import pandas as pd
+
+    from boring_semantic_layer import Dimension, Measure
+    from boring_semantic_layer.serialization import from_tagged, to_tagged
+
+    con = ibis.duckdb.connect(":memory:")
+    flights = pd.DataFrame(
+        {
+            "origin": ["SEA", "SEA", "LAX", "LAX", "ORD"],
+            "dep_time": pd.to_datetime(
+                [
+                    "2024-01-15 08:00",
+                    "2024-02-15 14:00",
+                    "2024-01-15 08:00",
+                    "2024-02-15 20:00",
+                    "2024-03-15 14:00",
+                ]
+            ),
+            "carrier": ["AA", "UA", "AA", "DL", "UA"],
+        }
+    )
+    carriers = pd.DataFrame(
+        {
+            "code": ["AA", "UA", "DL"],
+            "nickname": ["American", "United", "Delta"],
+        }
+    )
+    f_tbl = con.create_table("flights_card", flights)
+    c_tbl = con.create_table("carriers_card", carriers)
+
+    flights_st = (
+        to_semantic_table(f_tbl, name="flights_card")
+        .with_dimensions(
+            origin=Dimension(expr=lambda t: t.origin, description="Origin"),
+            dep_month=Dimension(
+                expr=lambda t: t.dep_time.truncate("M"), description="Dep month"
+            ),
+        )
+        .with_measures(
+            flight_count=Measure(expr=lambda t: t.count(), description="Count"),
+        )
+    )
+    carriers_st = (
+        to_semantic_table(c_tbl, name="carriers_card")
+        .with_dimensions(
+            code=Dimension(expr=lambda t: t.code, description="Code"),
+            nickname=Dimension(expr=lambda t: t.nickname, description="Nickname"),
+        )
+        .with_measures(
+            carrier_count=Measure(expr=lambda t: t.count(), description="Count"),
+        )
+    )
+
+    joined = flights_st.join_one(carriers_st, on=lambda f, c: f.carrier == c.code)
+
+    # Baseline: group by derived dimension + prefixed measure before round-trip
+    baseline = (
+        joined.group_by("flights_card.dep_month")
+        .aggregate("flights_card.flight_count")
+        .order_by("flights_card.dep_month")
+        .execute()
+    )
+
+    # Round-trip
+    tagged = to_tagged(joined)
+    reconstructed = from_tagged(tagged)
+
+    # Verify cardinality is preserved
+    assert reconstructed.op().cardinality == "one"
+
+    result = (
+        reconstructed.group_by("flights_card.dep_month")
+        .aggregate("flights_card.flight_count")
+        .order_by("flights_card.dep_month")
+        .execute()
+    )
+
+    assert len(result) == len(baseline)
+    assert list(result["flights_card.dep_month"]) == list(baseline["flights_card.dep_month"])
+    assert list(result["flights_card.flight_count"]) == list(
+        baseline["flights_card.flight_count"]
+    )
+    # Verify total is correct (should sum to 5)
+    assert result["flights_card.flight_count"].sum() == 5
+
+
 @pytest.mark.parametrize(
     "n_joins",
     [2, 3, 4],


### PR DESCRIPTION
## Summary
- **Root cause**: `_reconstruct_join` always used `join_many`, losing the original `join_one` cardinality after `to_tagged → from_tagged`. This forced the aggregate through the pre-aggregation path (`has_join_many=True`), which computed the wrong grain for derived dimensions (e.g., used raw `dep_time` instead of `dep_time.truncate("M")`).
- Serialize `cardinality` in join metadata so it survives round-trips
- Restore the correct `join_one`/`join_many` in `_reconstruct_join` based on deserialized cardinality
- Fix pre-agg grain computation to materialize derived dimensions on the raw table instead of using the underlying column name
- Add regression test for round-tripped `join_one` with derived dimension + prefixed measure

## Test plan
- [x] All 849 existing tests pass
- [x] New `test_tagged_roundtrip_join_one_preserves_cardinality` verifies cardinality is preserved and derived dim + prefixed measure produces correct results after round-trip
- [x] Existing `test_tagged_roundtrip_join_derived_dimension_on_root` still passes
- [x] BI traps tests (63 tests) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)