### PR TITLE
feat: expose BSL TagHandler via xorq.from_tag_node entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "pyyaml>=6.0",
     "returns>=0.26.0",
     "toolz>=1.0.0",
-    "xorq>=0.3.14",
+    "xorq>=0.3.19",
 ]
 urls = { Homepage = "https://github.com/boringdata/boring-semantic-layer/tree/main" }
 license = "MIT"
@@ -121,9 +121,3 @@ known-first-party = ["boring_semantic_layer"]
 dev = [
     "ipython>=8.38.0",
 ]
-
-# Pin xorq to a specific revision that ships the xorq.expr.builders
-# TagHandler registry (required by boring_semantic_layer.xorq_integration).
-# TODO: drop this pin once xorq publishes a release containing commit 4b3d8033.
-[tool.uv.sources]
-xorq = { git = "https://github.com/xorq-labs/xorq.git", rev = "4b3d8033" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ license-files = [
 bsl = "boring_semantic_layer.agents.cli:main"
 
 [project.entry-points."xorq.from_tag_node"]
-bsl = "boring_semantic_layer.xorq_integration:bsl_tag_handler"
+bsl = "boring_semantic_layer.serialization.tag_handler:bsl_tag_handler"
 
 [project.optional-dependencies]
 examples = ["xorq[duckdb]>=0.3.4", "xorq", "duckdb<1.4"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ license-files = [
 [project.scripts]
 bsl = "boring_semantic_layer.agents.cli:main"
 
+[project.entry-points."xorq.from_tag_node"]
+bsl = "boring_semantic_layer.xorq_integration:bsl_tag_handler"
+
 [project.optional-dependencies]
 examples = ["xorq[duckdb]>=0.3.4", "xorq", "duckdb<1.4"]
 
@@ -118,3 +121,9 @@ known-first-party = ["boring_semantic_layer"]
 dev = [
     "ipython>=8.38.0",
 ]
+
+# Pin xorq to a specific revision that ships the xorq.expr.builders
+# TagHandler registry (required by boring_semantic_layer.xorq_integration).
+# TODO: drop this pin once xorq publishes a release containing commit 4b3d8033.
+[tool.uv.sources]
+xorq = { git = "https://github.com/xorq-labs/xorq.git", rev = "4b3d8033" }

--- a/src/boring_semantic_layer/serialization/tag_handler.py
+++ b/src/boring_semantic_layer/serialization/tag_handler.py
@@ -18,12 +18,12 @@ from typing import Any
 
 from xorq.expr.builders import TagHandler
 
-from .serialization import (
+from . import (
     BSLSerializationContext,
     extract_xorq_metadata,
     reconstruct_bsl_operation,
 )
-from .serialization.freeze import thaw
+from .freeze import thaw
 
 
 def extract_metadata(tag_node) -> dict[str, Any]:

--- a/src/boring_semantic_layer/tests/test_xorq_tag_handler.py
+++ b/src/boring_semantic_layer/tests/test_xorq_tag_handler.py
@@ -1,0 +1,162 @@
+"""Tests for boring_semantic_layer.xorq_integration TagHandler.
+
+Verifies the acceptance criteria of XOR-295:
+
+* ``bsl_tag_handler`` is a valid ``TagHandler`` with ``tag_names=("bsl",)``.
+* ``extract_metadata`` returns the sidecar dict by walking nested metadata
+  down to the innermost ``SemanticTableOp``.
+* ``from_tag_node`` returns the base ``SemanticModel`` (not the full query
+  chain) reconstructed from the innermost ``SemanticTableOp`` source.
+* The handler is discoverable via the ``xorq.from_tag_node`` entry point.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+
+import ibis
+import pytest
+
+from boring_semantic_layer import SemanticModel
+from boring_semantic_layer.serialization import to_tagged
+from boring_semantic_layer.xorq_integration import (
+    bsl_tag_handler,
+    extract_metadata,
+    from_tag_node,
+)
+
+
+@pytest.fixture
+def simple_model():
+    table = ibis.memtable({"a": [1, 2, 3], "b": [4, 5, 6]})
+    return SemanticModel(
+        table=table,
+        dimensions={"a": lambda t: t.a, "b": lambda t: t.b},
+        measures={"sum_b": lambda t: t.b.sum(), "avg_b": lambda t: t.b.mean()},
+        name="simple",
+    )
+
+
+def _tag_node(tagged_expr):
+    """Return the outermost Tag op on a BSL-tagged expression."""
+    return tagged_expr.op()
+
+
+# ---------------------------------------------------------------------------
+# TagHandler shape
+# ---------------------------------------------------------------------------
+
+
+def test_bsl_tag_handler_is_valid():
+    from xorq.expr.builders import TagHandler
+
+    assert isinstance(bsl_tag_handler, TagHandler)
+    assert bsl_tag_handler.tag_names == ("bsl",)
+    assert bsl_tag_handler.extract_metadata is extract_metadata
+    assert bsl_tag_handler.from_tag_node is from_tag_node
+
+
+# ---------------------------------------------------------------------------
+# Entry-point discovery
+# ---------------------------------------------------------------------------
+
+
+def test_entry_point_registered():
+    """BSL registers bsl_tag_handler under xorq.from_tag_node."""
+    eps = importlib.metadata.entry_points(group="xorq.from_tag_node")
+    names = {ep.name for ep in eps}
+    assert "bsl" in names, f"bsl entry point missing; found {names}"
+
+    ep = next(ep for ep in eps if ep.name == "bsl")
+    assert ep.load() is bsl_tag_handler
+
+
+def test_handler_discovered_by_xorq_registry():
+    """xorq's registry resolves 'bsl' to our handler (builtin or entry point)."""
+    from xorq.expr.builders import _get_from_tag_node_registry
+
+    registry = _get_from_tag_node_registry()
+    assert "bsl" in registry
+    handler = registry["bsl"]
+    # Either our handler directly (via entry point when builtin is removed) or
+    # xorq's current builtin that delegates to BSL — both must expose from_tag_node.
+    assert handler.from_tag_node is not None
+
+
+# ---------------------------------------------------------------------------
+# extract_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_extract_metadata_on_base_model(simple_model):
+    """Direct SemanticTableOp tag → dims/measures read off the tag."""
+    tag_node = _tag_node(to_tagged(simple_model))
+
+    meta = extract_metadata(tag_node)
+
+    assert meta["type"] == "semantic_model"
+    assert set(meta["dimensions"]) == {"a", "b"}
+    assert set(meta["measures"]) == {"sum_b", "avg_b"}
+    assert "2 dims" in meta["description"]
+    assert "2 measures" in meta["description"]
+
+
+def test_extract_metadata_walks_source_chain(simple_model):
+    """After a query (wraps SemanticTableOp in SemanticAggregateOp etc.), the
+    handler still reaches the innermost SemanticTableOp for dim/measure names."""
+    query = simple_model.query(dimensions=("a",), measures=("sum_b",))
+    tag_node = _tag_node(to_tagged(query))
+
+    meta = extract_metadata(tag_node)
+
+    # Names come from the base model, not just the projected query columns.
+    assert set(meta["dimensions"]) == {"a", "b"}
+    assert set(meta["measures"]) == {"sum_b", "avg_b"}
+
+
+# ---------------------------------------------------------------------------
+# from_tag_node
+# ---------------------------------------------------------------------------
+
+
+def test_from_tag_node_returns_base_model(simple_model):
+    tag_node = _tag_node(to_tagged(simple_model))
+
+    recovered = from_tag_node(tag_node)
+
+    # Behaves like a SemanticModel — has .query, dims, measures.
+    assert hasattr(recovered, "query")
+    assert set(recovered.dimensions) == {"a", "b"}
+    assert set(recovered.measures) == {"sum_b", "avg_b"}
+
+
+def test_from_tag_node_on_query_recovers_base_model(simple_model):
+    """Even when the tagged expression is a query chain, from_tag_node returns
+    the base SemanticModel so callers can issue fresh .query() calls."""
+    query = simple_model.query(dimensions=("a",), measures=("sum_b",))
+    tag_node = _tag_node(to_tagged(query))
+
+    recovered = from_tag_node(tag_node)
+
+    # Base model: all original dims/measures are present, not just the
+    # projected subset.
+    assert set(recovered.dimensions) == {"a", "b"}
+    assert set(recovered.measures) == {"sum_b", "avg_b"}
+
+    # Fresh query works against the recovered model.
+    recovered.query(dimensions=("b",), measures=("avg_b",))
+
+
+# ---------------------------------------------------------------------------
+# expr.op.builder integration (xorq dispatch)
+# ---------------------------------------------------------------------------
+
+
+def test_ls_builder_dispatches_to_handler(simple_model):
+    """xorq's `expr.ls.builder` walks tags and returns our SemanticModel."""
+    tagged_expr = to_tagged(simple_model)
+
+    recovered = tagged_expr.ls.builder
+
+    assert set(recovered.dimensions) == {"a", "b"}
+    assert set(recovered.measures) == {"sum_b", "avg_b"}

--- a/src/boring_semantic_layer/tests/test_xorq_tag_handler.py
+++ b/src/boring_semantic_layer/tests/test_xorq_tag_handler.py
@@ -19,7 +19,7 @@ import pytest
 
 from boring_semantic_layer import SemanticModel
 from boring_semantic_layer.serialization import to_tagged
-from boring_semantic_layer.xorq_integration import (
+from boring_semantic_layer.serialization.tag_handler import (
     bsl_tag_handler,
     extract_metadata,
     from_tag_node,

--- a/src/boring_semantic_layer/xorq_integration.py
+++ b/src/boring_semantic_layer/xorq_integration.py
@@ -1,0 +1,79 @@
+"""xorq integration: TagHandler for BSL-tagged expressions.
+
+Exposes a ``xorq.expr.builders.TagHandler`` instance that xorq discovers via
+the ``xorq.from_tag_node`` entry point group, so xorq no longer needs to
+hard-code BSL-specific logic.
+
+- :func:`extract_metadata` — walks nested tag-node metadata to the innermost
+  ``SemanticTableOp`` and returns a sidecar dict (dimension/measure names) for
+  the catalog.
+- :func:`from_tag_node` — reconstructs the base ``SemanticModel`` (the
+  ``SemanticTableOp`` at the bottom of the source chain), not the full query
+  chain, so callers can issue fresh ``.query()`` calls.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from xorq.expr.builders import TagHandler
+
+from .serialization import (
+    BSLSerializationContext,
+    extract_xorq_metadata,
+    reconstruct_bsl_operation,
+)
+from .serialization.freeze import thaw
+
+
+def extract_metadata(tag_node) -> dict[str, Any]:
+    """Return sidecar metadata (dimension/measure names) for a BSL-tagged node.
+
+    Walks nested metadata (the ``source`` chain) down to the innermost
+    ``SemanticTableOp`` and extracts the dimension/measure name tuples.
+    """
+    table_meta: Any = tag_node.metadata
+    while table_meta.get("bsl_op_type") != "SemanticTableOp" and (
+        src := table_meta.get("source")
+    ):
+        table_meta = dict(src) if isinstance(src, tuple) else src
+    dims = tuple(d[0] for d in table_meta.get("dimensions", ()))
+    measures = tuple(m[0] for m in table_meta.get("measures", ()))
+    return {
+        "type": "semantic_model",
+        "description": f"{len(dims)} dims, {len(measures)} measures",
+        "dimensions": dims,
+        "measures": measures,
+    }
+
+
+def from_tag_node(tag_node):
+    """Reconstruct the base ``SemanticModel`` from a BSL-tagged node.
+
+    Walks to the innermost ``SemanticTableOp`` source and returns the base
+    model (not the surrounding query chain), so callers can issue new
+    ``.query()`` calls against it.
+    """
+    expr = tag_node.to_expr()
+    ctx = BSLSerializationContext()
+    # extract_xorq_metadata returns a shallow dict whose values are still
+    # frozen tuple-of-pairs; thaw each value so we can descend via plain
+    # dict lookups.
+    metadata = {k: thaw(v) for k, v in extract_xorq_metadata(expr).items()}
+    while src := metadata.get("source"):
+        metadata = src
+    return reconstruct_bsl_operation(metadata, expr, ctx)
+
+
+bsl_tag_handler = TagHandler(
+    tag_names=("bsl",),
+    extract_metadata=extract_metadata,
+    from_tag_node=from_tag_node,
+)
+
+
+__all__ = [
+    "bsl_tag_handler",
+    "extract_metadata",
+    "from_tag_node",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -283,9 +283,9 @@ requires-dist = [
     { name = "urllib3", marker = "extra == 'dev'", specifier = ">=2.2.3" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.30.0" },
     { name = "vl-convert-python", marker = "extra == 'viz-altair'", specifier = ">=1.0.0" },
-    { name = "xorq", specifier = ">=0.3.14" },
-    { name = "xorq", marker = "extra == 'examples'" },
-    { name = "xorq", extras = ["duckdb"], marker = "extra == 'examples'", specifier = ">=0.3.4" },
+    { name = "xorq", git = "https://github.com/xorq-labs/xorq.git?rev=4b3d8033" },
+    { name = "xorq", marker = "extra == 'examples'", git = "https://github.com/xorq-labs/xorq.git?rev=4b3d8033" },
+    { name = "xorq", extras = ["duckdb"], marker = "extra == 'examples'", git = "https://github.com/xorq-labs/xorq.git?rev=4b3d8033" },
 ]
 provides-extras = ["examples", "viz-altair", "viz-plotly", "viz-plotext", "agent", "mcp", "server", "dev"]
 
@@ -923,6 +923,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a5/97/fa35f5d13a803b8f16e59c1f18f06607b9df5683c08bd7cd7a48a29ce988/geoarrow_types-0.3.0.tar.gz", hash = "sha256:82243e4be88b268fa978ae5bba6c6680c3556735e795965b2fe3e6fbfea9f9ee", size = 23708, upload-time = "2025-05-27T03:39:39.979Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/16/e37cb1b0894c9cf3f9b1c50ebcfab56a0d9fe7c3b6f97d5680a7eb27ca08/geoarrow_types-0.3.0-py3-none-any.whl", hash = "sha256:439df6101632080442beccc7393cac54d6c7f6965da897554349e94d2492f613", size = 19025, upload-time = "2025-05-27T03:39:38.652Z" },
+]
+
+[[package]]
+name = "git-annex"
+version = "10.20260316"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/09/8a6fe029eae7c86ef36e123aa01e849245feac95d5088a34d7136fee8d9c/git_annex-10.20260316-py3-none-macosx_14_0_arm64.whl", hash = "sha256:171e0e096b7551cbedf7dc04eb5254721dbcdf9d18706fc7e926443afba777dc", size = 36279485, upload-time = "2026-03-17T17:33:31.127Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a4/f69d1f801d8d5a8fc03392718f737cfe1850706ad053eb06234ddf3cfd7a/git_annex-10.20260316-py3-none-macosx_15_0_x86_64.whl", hash = "sha256:21fc91c6fb31abe38890d774ed5b39436cfd3fe589e38772be519f5e633d71b8", size = 14231272, upload-time = "2026-03-17T17:51:37.648Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e1/04428018a0716a95f714fc0ce1a081e56c7796273ca3a959638d5b01643a/git_annex-10.20260316-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:9ddc96a077283df17c02b287fc07874546fc9cd32dc3904d996bc841ac04cdf7", size = 26247156, upload-time = "2026-03-17T17:24:28.34Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/36/b5f70dade258ce23ac0a7b33e4c8184be3dadb5a9fbad0bb773927ae1248/git_annex-10.20260316-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:157ec16270aa3cd6fd45f16de8963d9f9c298c260ec0fd460c92a2a52ea5a789", size = 21888939, upload-time = "2026-03-17T17:27:02.262Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/12/9689ee50c88d5632e612703505b104ae41a3f2d8b9a1fd27cb2f4744c3ae/git_annex-10.20260316-py3-none-win_amd64.whl", hash = "sha256:8bc63486ee1beffd7200f4e7e3323123641dd146067b104547bd85209b00b9b6", size = 27056643, upload-time = "2026-03-17T17:31:17.57Z" },
 ]
 
 [[package]]
@@ -2773,6 +2785,31 @@ wheels = [
 ]
 
 [[package]]
+name = "py-yaml12"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/eb/a0b260f7b8625d21c7a900311c863e899d2e258ebdc9a056a0cd17031f80/py_yaml12-0.1.0.tar.gz", hash = "sha256:e7b6140fad56d5528e6d51c7b8ff79bdb27631b73a9a7c1bc4b55fda1bddbaef", size = 117187, upload-time = "2025-12-16T18:06:44.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/d9/5f4ccd96d7c776e822e63d2b79e3594653bcf55720dbad1cdcbc18a170ad/py_yaml12-0.1.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f6dcce183b6744c0909a8440d1f7a00836023826e463601d03b879c0e84c8a19", size = 468720, upload-time = "2025-12-16T18:06:35.053Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ab/c08a62f92f69d45fc479b1e893968c9d9b2dc87809e538cea0409cdca25e/py_yaml12-0.1.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b9c8e54afc415d4eb038a024bc9e28fed95b8c447708bf1a24da0291bbfdd8", size = 501529, upload-time = "2025-12-16T18:06:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/05/a8408ca1f4de61f8ef626391908006fa1c5e54eaf0f3288d78bc663d65aa/py_yaml12-0.1.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e637189cb07e180bdc9db847ca5711b54df2233b55604bf3609cfa0f0228f7c", size = 519733, upload-time = "2025-12-16T18:06:22.646Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/73/4e1f7cdc26b1deb60ea42ca4b3717fab279a42df10f9b16b869550e92825/py_yaml12-0.1.0-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:003a9526a4731010f4e37eced9f33fd070ff563fe3bc2fe2416ab7598982b285", size = 640522, upload-time = "2025-12-16T18:06:25.551Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/a9/7be4ced3e490fd2a5e92cc8e8fe5b6143036a480ba004235e0a78ccbc6f9/py_yaml12-0.1.0-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6845871e3a0233d71f75e56caca5c350f48cb5d9c50e6bb37874243be1ca5f2b", size = 530277, upload-time = "2025-12-16T18:06:27.115Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0c/1e1b171246a44753bf04c6399179da1ccf99cfb9de1e086afd7326765b34/py_yaml12-0.1.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fbc5d54ec0471c0f64b931ea0907f655c728597b98a9e7f4a98f4c76cc3614ba", size = 516865, upload-time = "2025-12-16T18:06:31.845Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/00/b4d1db376b35f0021c7e45b6351536c217426b32f71ad8b89782a3a6b562/py_yaml12-0.1.0-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3d9f1ad2e166eb113fd4e44263baad929e268dc15abc7eb87736aa7148d07534", size = 557448, upload-time = "2025-12-16T18:06:28.78Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/41/828743df93b97ca987a808895f5171f2430ee61f18f25fe3d9033075879d/py_yaml12-0.1.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4c9fabfe8fdf53eb661eaaace95961dae742abe0679a9a989936e8b2cf893dbe", size = 683748, upload-time = "2025-12-16T18:06:37.961Z" },
+    { url = "https://files.pythonhosted.org/packages/74/b4/f293b9fa7ad26b86278840f3c571a211111091fd03ba553fa45e4bcaf780/py_yaml12-0.1.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:0226a5aeba67b97ed8e2947da332e5c3b5ef004c0058d2cff2413c99fc4b9ff4", size = 789703, upload-time = "2025-12-16T18:06:39.272Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/18/703812d770166e292e13388bf899f2540c83a8c9d6505862fe756b2818d1/py_yaml12-0.1.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:a29558b3ba9138eac75996dd0a92fda7993c085aa10c1c93b641239389b731be", size = 764707, upload-time = "2025-12-16T18:06:40.943Z" },
+    { url = "https://files.pythonhosted.org/packages/81/f5/936eb310b0c84d044d92ccd90b99b53fb8326dc6084ce59fe47a6b78eb93/py_yaml12-0.1.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:fcd21f854faf23bd1fff4822e7cf29a6e8b69dc43f69f6f2f34a698dcde4548b", size = 719443, upload-time = "2025-12-16T18:06:42.464Z" },
+    { url = "https://files.pythonhosted.org/packages/37/5b/eaa16c85074b44b1b6843d52fb3b75da26410dcea1e98cf6b6c4f46f27af/py_yaml12-0.1.0-cp310-abi3-win32.whl", hash = "sha256:2552c7957819f53b7d667baab38e59db066f067aafa6695849ae94c0f01bf999", size = 349644, upload-time = "2025-12-16T18:06:48.417Z" },
+    { url = "https://files.pythonhosted.org/packages/48/60/d50a1e5e44333aa6533080df9c587b6b25e0205071078c63619202592bb3/py_yaml12-0.1.0-cp310-abi3-win_amd64.whl", hash = "sha256:228ce36885a16dcaf20007bf7b74ae1b36ccd20a46149f369e4b8164e7542023", size = 362326, upload-time = "2025-12-16T18:06:45.271Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/9c/a2cc38da0d06fcf7c13c12e14208f933636a2d51c3e9867e120cfe4352d1/py_yaml12-0.1.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:f874ca279b1c58ec6a4853876a0e51b51e3a6d3474168a15529fd68fbf268ca7", size = 466296, upload-time = "2025-12-16T18:06:36.532Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0e/ec5ae405508f2cb6628ad74b6af8bbd1b87ffac432db1b70ffc621e96003/py_yaml12-0.1.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0720e3bd829d9887a7ce28e74e727af4e2c17c896b294d65c131361ba0767768", size = 513876, upload-time = "2025-12-16T18:06:33.303Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/26/9ccd16342fa44e55d6351da32d3718daada5aed6037469f4c3b9c7f79363/py_yaml12-0.1.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:90baa98b34c82660f5d856c54ee6c8505ab2428e72998f487972fd5ad0c40701", size = 553830, upload-time = "2025-12-16T18:06:30.127Z" },
+    { url = "https://files.pythonhosted.org/packages/36/3f/6f09b4f5384b9b0a1d42a0945641a89439b1fe5becc27de064ae56c8059c/py_yaml12-0.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:9a8fedadf47b35da5224e26936ddc26ed379fa0a184aaff709cbb75a2cf0df21", size = 359955, upload-time = "2025-12-16T18:06:47.199Z" },
+]
+
+[[package]]
 name = "pyarrow"
 version = "21.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3077,18 +3114,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/86/9e3c5f48f7b7b638b216e4b9e645f54d199d7abbbab7a64a13b4e12ba10f/pytest_asyncio-1.2.0.tar.gz", hash = "sha256:c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57", size = 50119, upload-time = "2025-09-12T07:33:53.816Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/93/2fa34714b7a4ae72f2f8dad66ba17dd9a2c793220719e736dda28b7aec27/pytest_asyncio-1.2.0-py3-none-any.whl", hash = "sha256:8e17ae5e46d8e7efe51ab6494dd2010f4ca8dae51652aa3c8d55acf50bfb2e99", size = 15095, upload-time = "2025-09-12T07:33:52.639Z" },
-]
-
-[[package]]
-name = "pytest-mock"
-version = "3.15.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
 ]
 
 [[package]]
@@ -4366,8 +4391,8 @@ wheels = [
 
 [[package]]
 name = "xorq"
-version = "0.3.14"
-source = { registry = "https://pypi.org/simple" }
+version = "0.3.18"
+source = { git = "https://github.com/xorq-labs/xorq.git?rev=4b3d8033#4b3d8033337c2171c545f2e7034c97031ac0063d" }
 dependencies = [
     { name = "atpublic" },
     { name = "attrs", marker = "python_full_version < '4'" },
@@ -4379,6 +4404,7 @@ dependencies = [
     { name = "envyaml" },
     { name = "filelock" },
     { name = "geoarrow-types", marker = "python_full_version < '4'" },
+    { name = "git-annex" },
     { name = "gitpython" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
@@ -4387,26 +4413,22 @@ dependencies = [
     { name = "pandas", marker = "python_full_version < '4'" },
     { name = "parsy" },
     { name = "prometheus-client" },
+    { name = "py-yaml12" },
     { name = "pyarrow", marker = "python_full_version < '4'" },
     { name = "pyarrow-hotfix", marker = "python_full_version < '4'" },
-    { name = "pytest-mock", marker = "python_full_version < '4'" },
     { name = "python-dateutil" },
     { name = "pythran", marker = "sys_platform == 'darwin'" },
     { name = "pytz" },
-    { name = "pyyaml" },
     { name = "rich" },
     { name = "sqlglot" },
     { name = "strenum", marker = "python_full_version < '3.11'" },
     { name = "structlog", marker = "python_full_version < '4'" },
     { name = "textual" },
+    { name = "tomlkit" },
     { name = "toolz" },
     { name = "typing-extensions" },
     { name = "uv" },
     { name = "xorq-datafusion" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/e4/871448e8423cd6badeef093e010617c373e473782d770ec0cac085573ee4/xorq-0.3.14.tar.gz", hash = "sha256:4abe4ab6209b125cc5e0db0a2e58aa7bbacf418f67c0a955e0b8478499c79337", size = 1551002, upload-time = "2026-03-09T20:35:13.691Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/0d/ececae397e08da8a0684ae50281afe15214891f59386afed7c16375a448e/xorq-0.3.14-py3-none-any.whl", hash = "sha256:9ae8f217f70facf13ecdac6df008788db11dae24326038952db32c42effe7812", size = 1788923, upload-time = "2026-03-09T20:35:16.953Z" },
 ]
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -283,9 +283,9 @@ requires-dist = [
     { name = "urllib3", marker = "extra == 'dev'", specifier = ">=2.2.3" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.30.0" },
     { name = "vl-convert-python", marker = "extra == 'viz-altair'", specifier = ">=1.0.0" },
-    { name = "xorq", git = "https://github.com/xorq-labs/xorq.git?rev=4b3d8033" },
-    { name = "xorq", marker = "extra == 'examples'", git = "https://github.com/xorq-labs/xorq.git?rev=4b3d8033" },
-    { name = "xorq", extras = ["duckdb"], marker = "extra == 'examples'", git = "https://github.com/xorq-labs/xorq.git?rev=4b3d8033" },
+    { name = "xorq", specifier = ">=0.3.19" },
+    { name = "xorq", marker = "extra == 'examples'" },
+    { name = "xorq", extras = ["duckdb"], marker = "extra == 'examples'", specifier = ">=0.3.4" },
 ]
 provides-extras = ["examples", "viz-altair", "viz-plotly", "viz-plotext", "agent", "mcp", "server", "dev"]
 
@@ -4391,8 +4391,8 @@ wheels = [
 
 [[package]]
 name = "xorq"
-version = "0.3.18"
-source = { git = "https://github.com/xorq-labs/xorq.git?rev=4b3d8033#4b3d8033337c2171c545f2e7034c97031ac0063d" }
+version = "0.3.19"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "atpublic" },
     { name = "attrs", marker = "python_full_version < '4'" },
@@ -4429,6 +4429,10 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uv" },
     { name = "xorq-datafusion" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/5f/17f6fe75773c313c688728a5273e818890a3307a009e54a69f0565a76079/xorq-0.3.19.tar.gz", hash = "sha256:3e0c46246db2bcd7653c0f581b7264fe49d48bfcda1ae40dcbea050581145726", size = 1964477, upload-time = "2026-04-14T13:14:23.58Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/04/aa60dc5f4fb30e12debbac2354b534c3f336467cc93db6769902f68ab312/xorq-0.3.19-py3-none-any.whl", hash = "sha256:eb55e59202c70f471be295882828f09e6728f43c7b04291c8013ca89b2ca5e69", size = 1898204, upload-time = "2026-04-14T13:14:21.966Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Move BSL-specific tag handling out of xorq: BSL now ships a TagHandler (boring_semantic_layer.xorq_integration:bsl_tag_handler) and registers it under the xorq.from_tag_node entry point group, so xorq's registry discovers it automatically without hard-coded BSL knowledge.

- extract_metadata walks nested tag-node metadata down to the innermost SemanticTableOp and returns the sidecar dict (dimension/measure names).
- from_tag_node reconstructs the base SemanticModel from the innermost SemanticTableOp source, not the full query chain, so callers can issue fresh .query() calls.
- Pin xorq to 4b3d8033 via [tool.uv.sources] until a release ships the xorq.expr.builders TagHandler registry.