### PR TITLE
feat: add period comparison workflow for MCP

### DIFF
--- a/docs/md/doc/mcp.md
+++ b/docs/md/doc/mcp.md
@@ -183,6 +183,23 @@ Execute queries against a semantic model with dimensions, measures, filters, and
 - When `chart_spec` is provided: `{"records": [...], "chart": {...}}`
 - When `chart_spec` is not provided: `{"records": [...]}`
 
+### compare_periods
+
+Compare two explicit time ranges and return `{measure}_current`, `{measure}_previous`, `{measure}_delta`, and `{measure}_pct_change` columns in a single response. This is the recommended MCP pattern for period-over-period chat questions.
+
+**Parameters:**
+- `model_name` (str): Name of the model to query
+- `measures` (list[str]): Measures to compare
+- `current_time_range` (dict): Current period with `start` and `end`
+- `previous_time_range` (dict): Comparison period with `start` and `end`
+- `dimensions` (list[str], optional): Optional grouping dimensions like `carrier` or `store`
+- `filters` (list[dict], optional): Optional filters applied to both periods
+- `time_dimension` (str, optional): Explicit time dimension when a model has more than one
+
+**Example usage in Claude:**
+> "Compare the last 10 days to the prior 10 days by carrier"
+> "Show revenue this month vs last month by store"
+
 ### Example Interactions
 
 Here are some example questions you can ask Claude when the MCP server is configured:

--- a/docs/md/doc/query-agent-mcp.md
+++ b/docs/md/doc/query-agent-mcp.md
@@ -183,6 +183,23 @@ Execute queries against a semantic model with dimensions, measures, filters, and
 - When `chart_spec` is provided: `{"records": [...], "chart": {...}}`
 - When `chart_spec` is not provided: `{"records": [...]}`
 
+### compare_periods
+
+Compare two explicit time ranges and return `{measure}_current`, `{measure}_previous`, `{measure}_delta`, and `{measure}_pct_change` columns in a single response. This is the recommended MCP pattern for period-over-period chat questions.
+
+**Parameters:**
+- `model_name` (str): Name of the model to query
+- `measures` (list[str]): Measures to compare
+- `current_time_range` (dict): Current period with `start` and `end`
+- `previous_time_range` (dict): Comparison period with `start` and `end`
+- `dimensions` (list[str], optional): Optional grouping dimensions like `carrier` or `store`
+- `filters` (list[dict], optional): Optional filters applied to both periods
+- `time_dimension` (str, optional): Explicit time dimension when a model has more than one
+
+**Example usage in Claude:**
+> "Compare the last 10 days to the prior 10 days by carrier"
+> "Show revenue this month vs last month by store"
+
 ### Example Interactions
 
 Here are some example questions you can ask Claude when the MCP server is configured:

--- a/docs/md/prompts/query/mcp/system.md
+++ b/docs/md/prompts/query/mcp/system.md
@@ -31,3 +31,4 @@ This server provides a semantic layer for querying structured data with support 
 - get_model: get model metadata (dimensions, measures, time dimensions)
 - get_time_range: get available time range for time dimensions
 - query_model: execute queries with time_grain, time_range, and chart_spec support
+- compare_periods: compare two explicit time ranges and return current/previous/delta/pct_change columns

--- a/docs/md/prompts/query/mcp/tool-query.md
+++ b/docs/md/prompts/query/mcp/tool-query.md
@@ -232,6 +232,24 @@ When None, returns only data: `{"records": [...]}`
 }
 ```
 
+## Period-over-Period Comparisons
+
+For WoW, MoM, QoQ, YoY, or custom period-vs-period analysis, prefer the dedicated `compare_periods` tool instead of trying to force everything through `query_model`. It returns `{measure}_current`, `{measure}_previous`, `{measure}_delta`, and `{measure}_pct_change` columns in one response.
+
+Example:
+```python
+compare_periods(
+    model_name="orders",
+    dimensions=["orders.region"],
+    measures=["orders.total_sales"],
+    current_time_range={"start": "2024-02-01", "end": "2024-02-29"},
+    previous_time_range={"start": "2024-01-01", "end": "2024-01-31"},
+    order_by=[["total_sales_delta", "desc"]]
+)
+```
+
+Use `query_model` when you only need a single period or want to build your own windowed analysis.
+
 ## Common Query Patterns
 
 ### Simple Aggregation

--- a/src/boring_semantic_layer/agents/backends/mcp.py
+++ b/src/boring_semantic_layer/agents/backends/mcp.py
@@ -270,6 +270,142 @@ class MCPSemanticModel(FastMCP):
             )
 
         @self.tool(
+            name="compare_periods",
+            description=(
+                "Compare two explicit time ranges for one model and return current, previous, "
+                "delta, and pct_change columns. Use this for WoW, MoM, QoQ, YoY, or custom "
+                "period-vs-period analysis in LLM chat workflows."
+            ),
+        )
+        def compare_periods(
+            model_name: str,
+            measures: Annotated[
+                list[str],
+                BeforeValidator(_parse_json_string),
+                Field(
+                    description="Measure names to compare across the two periods.",
+                ),
+            ],
+            current_time_range: Annotated[
+                dict[str, str],
+                BeforeValidator(_parse_json_string),
+                Field(
+                    description="Current period time range with ISO start/end keys.",
+                ),
+            ],
+            previous_time_range: Annotated[
+                dict[str, str],
+                BeforeValidator(_parse_json_string),
+                Field(
+                    description="Previous comparison period time range with ISO start/end keys.",
+                ),
+            ],
+            dimensions: Annotated[
+                list[str] | None,
+                BeforeValidator(_parse_json_string),
+                Field(
+                    default=None,
+                    description="Optional grouping dimensions such as ['carrier'] or ['store'].",
+                ),
+            ] = None,
+            filters: Annotated[
+                list[dict[str, Any]] | None,
+                BeforeValidator(_parse_json_string),
+                Field(
+                    default=None,
+                    description="Optional filters applied to both periods before comparison.",
+                ),
+            ] = None,
+            time_dimension: Annotated[
+                str | None,
+                Field(
+                    default=None,
+                    description="Optional explicit time dimension if the model has multiple time dimensions.",
+                ),
+            ] = None,
+            time_grain: Annotated[
+                str | None,
+                Field(
+                    default=None,
+                    description="Optional shared time grain when the comparison also groups by a time dimension.",
+                ),
+            ] = None,
+            time_grains: Annotated[
+                dict[str, str] | None,
+                BeforeValidator(_parse_json_string),
+                Field(
+                    default=None,
+                    description="Optional per-dimension time grains. Cannot be used with time_grain.",
+                ),
+            ] = None,
+            order_by: Annotated[
+                list[list[str]] | None,
+                BeforeValidator(_parse_json_string),
+                Field(
+                    default=None,
+                    description="Optional sort order for the comparison result, e.g. [['flight_count_delta', 'desc']].",
+                    json_schema_extra={"items": {"type": "array", "items": {"type": "string"}}},
+                ),
+            ] = None,
+            limit: Annotated[
+                int | None,
+                Field(default=None, description="Optional row limit after comparison."),
+            ] = None,
+            get_records: Annotated[
+                bool,
+                Field(default=True, description=load_prompt(PROMPTS_DIR, "tool-query-param-get_records.md")),
+            ] = True,
+            records_limit: Annotated[
+                int | None,
+                Field(default=None, description=load_prompt(PROMPTS_DIR, "tool-query-param-records_limit.md")),
+            ] = None,
+            get_chart: Annotated[
+                bool,
+                Field(default=True, description=load_prompt(PROMPTS_DIR, "tool-query-param-get_chart.md")),
+            ] = True,
+            chart_backend: Annotated[
+                str | None,
+                Field(default=None, description=load_prompt(PROMPTS_DIR, "tool-query-param-chart_backend.md")),
+            ] = None,
+            chart_format: Annotated[
+                str | None,
+                Field(default=None, description=load_prompt(PROMPTS_DIR, "tool-query-param-chart_format.md")),
+            ] = None,
+            chart_spec: Annotated[
+                dict[str, Any] | None,
+                BeforeValidator(_parse_json_string),
+                Field(default=None, description=load_prompt(PROMPTS_DIR, "tool-query-param-chart_spec.md")),
+            ] = None,
+        ) -> str:
+            if model_name not in self.models:
+                raise ValueError(f"Model {model_name} not found")
+
+            model = self.models[model_name]
+            query_result = model.compare_periods(
+                dimensions=dimensions,
+                measures=measures,
+                current_time_range=current_time_range,
+                previous_time_range=previous_time_range,
+                filters=filters or [],
+                time_dimension=time_dimension,
+                time_grain=time_grain,
+                time_grains=time_grains,
+                order_by=order_by,
+                limit=limit,
+            )
+
+            return generate_chart_with_data(
+                query_result,
+                get_records=get_records,
+                records_limit=records_limit,
+                get_chart=get_chart,
+                chart_backend=chart_backend,
+                chart_format=chart_format,
+                chart_spec=chart_spec,
+                default_backend="altair",
+            )
+
+        @self.tool(
             name="search_dimension_values",
             description=load_prompt(PROMPTS_DIR, "tool-search-dimension-values-desc.md"),
         )

--- a/src/boring_semantic_layer/expr.py
+++ b/src/boring_semantic_layer/expr.py
@@ -39,6 +39,7 @@ from .ops import (
     _normalize_join_predicate,
     _normalize_to_name,
 )
+from .query import compare_periods as build_compare_periods
 from .query import query as build_query
 
 _JOIN_REMOVED_MESSAGE = (
@@ -755,6 +756,33 @@ class SemanticModel(SemanticTable):
             time_grains=time_grains,
             time_range=time_range,
             having=having,
+        )
+
+    def compare_periods(
+        self,
+        dimensions: Sequence[str] | None = None,
+        measures: Sequence[str] | None = None,
+        current_time_range: dict[str, str] | None = None,
+        previous_time_range: dict[str, str] | None = None,
+        filters: list | None = None,
+        time_dimension: str | None = None,
+        time_grain: str | None = None,
+        time_grains: dict[str, str] | None = None,
+        order_by: Sequence[tuple[str, str]] | None = None,
+        limit: int | None = None,
+    ):
+        return build_compare_periods(
+            semantic_table=self,
+            dimensions=dimensions,
+            measures=measures,
+            current_time_range=current_time_range,
+            previous_time_range=previous_time_range,
+            filters=filters,
+            time_dimension=time_dimension,
+            time_grain=time_grain,
+            time_grains=time_grains,
+            order_by=order_by,
+            limit=limit,
         )
 
 

--- a/src/boring_semantic_layer/query.py
+++ b/src/boring_semantic_layer/query.py
@@ -152,6 +152,12 @@ def _find_time_dimension(semantic_table: Any, dimensions: list[str]) -> str | No
     return next((dim for dim in dimensions if is_time_dim(dim)), None)
 
 
+def _find_any_time_dimension(semantic_table: Any) -> str | None:
+    """Find the first declared time dimension on a semantic table."""
+    dims_dict = semantic_table.get_dimensions()
+    return next((name for name, dim in dims_dict.items() if dim.is_time_dimension), None)
+
+
 @curry
 def _make_grain_id(grain: str) -> str:
     """Convert grain name to TIME_GRAIN_ identifier (curried)."""
@@ -556,6 +562,156 @@ def _split_filter(
         pre_agg.append(filter_spec)
 
 
+def _build_time_range_filters(semantic_table: Any, time_dimension: str, time_range: Mapping[str, str]) -> list[Callable]:
+    """Build reusable filters for a specific time dimension and range."""
+    if not isinstance(time_range, dict) or "start" not in time_range or "end" not in time_range:
+        raise ValueError("time_range must be a dict with 'start' and 'end' keys")
+
+    from datetime import datetime
+
+    dim_obj = semantic_table.get_dimensions().get(time_dimension)
+    if dim_obj is None:
+        raise ValueError(
+            f"Dimension '{time_dimension}' not found. "
+            f"Available dimensions: {list(semantic_table.get_dimensions().keys())}"
+        )
+    if not dim_obj.is_time_dimension:
+        raise ValueError(
+            f"Dimension '{time_dimension}' is not a time dimension. "
+            "compare_periods and time ranges require a time dimension."
+        )
+
+    start_dt = datetime.fromisoformat(time_range["start"])
+    end_dt = datetime.fromisoformat(time_range["end"])
+    if end_dt < start_dt:
+        raise ValueError("time_range end must be greater than or equal to start")
+    return [
+        lambda t, dim=dim_obj, start=start_dt: dim(t) >= start,
+        lambda t, dim=dim_obj, end=end_dt: dim(t) <= end,
+    ]
+
+
+def compare_periods(
+    semantic_table: Any,
+    dimensions: Sequence[str] | None = None,
+    measures: Sequence[str] | None = None,
+    current_time_range: Mapping[str, str] | None = None,
+    previous_time_range: Mapping[str, str] | None = None,
+    filters: Sequence[dict[str, Any] | str | Callable | Filter] | None = None,
+    time_dimension: str | None = None,
+    time_grain: TimeGrain | None = None,
+    time_grains: Mapping[str, TimeGrain] | None = None,
+    order_by: Sequence[tuple[str, str]] | None = None,
+    limit: int | None = None,
+) -> Any:
+    """Compare two time ranges and return current/previous/delta columns."""
+    from .api import to_semantic_table
+
+    dimensions = list(dimensions or [])
+    measures = list(measures or [])
+    filters = list(filters or [])
+
+    if not measures:
+        raise ValueError("compare_periods requires at least one measure")
+    if current_time_range is None or previous_time_range is None:
+        raise ValueError(
+            "compare_periods requires both 'current_time_range' and 'previous_time_range'"
+        )
+
+    dims_dict = semantic_table.get_dimensions()
+    known_dimensions = set(dims_dict)
+    known_measures = set(semantic_table.get_measures()) | set(semantic_table.get_calculated_measures())
+    model_name = getattr(semantic_table, "name", None)
+
+    dimensions = _normalize_fields(dimensions, known_dimensions, expected_prefix=model_name)
+    measures = _normalize_fields(measures, known_measures, expected_prefix=model_name)
+
+    resolved_time_dimension = time_dimension
+    if resolved_time_dimension is not None:
+        resolved_time_dimension = _normalize_fields(
+            [resolved_time_dimension], known_dimensions, expected_prefix=model_name
+        )[0]
+    else:
+        resolved_time_dimension = _find_time_dimension(semantic_table, dimensions) or _find_any_time_dimension(
+            semantic_table
+        )
+
+    if resolved_time_dimension is None:
+        raise ValueError(
+            "compare_periods requires a time dimension. Mark one with "
+            ".with_dimensions(dim_name={'expr': ..., 'is_time_dimension': True}) "
+            "or pass time_dimension explicitly."
+        )
+
+    current_result = query(
+        semantic_table=semantic_table,
+        dimensions=dimensions,
+        measures=measures,
+        filters=[*filters, *_build_time_range_filters(semantic_table, resolved_time_dimension, current_time_range)],
+        time_grain=time_grain,
+        time_grains=time_grains,
+    )
+    previous_result = query(
+        semantic_table=semantic_table,
+        dimensions=dimensions,
+        measures=measures,
+        filters=[*filters, *_build_time_range_filters(semantic_table, resolved_time_dimension, previous_time_range)],
+        time_grain=time_grain,
+        time_grains=time_grains,
+    )
+
+    current_tbl = current_result.as_table().table.rename(
+        {f"{measure}_current": measure for measure in measures}
+    )
+    previous_tbl = previous_result.as_table().table.rename(
+        {
+            **{f"{measure}_previous": measure for measure in measures},
+            **{f"__previous_{dim}": dim for dim in dimensions},
+        }
+    )
+
+    if dimensions:
+        join_predicates = [current_tbl[dim] == previous_tbl[f"__previous_{dim}"] for dim in dimensions]
+        joined = current_tbl.join(previous_tbl, join_predicates, how="outer")
+        result_tbl = joined.select(
+            *[
+                joined[dim].coalesce(joined[f"__previous_{dim}"]).name(dim)
+                for dim in dimensions
+            ],
+            *[joined[f"{measure}_current"] for measure in measures],
+            *[joined[f"{measure}_previous"] for measure in measures],
+        )
+    else:
+        joined = current_tbl.join(previous_tbl, how="cross")
+        result_tbl = joined.select(
+            *[joined[f"{measure}_current"] for measure in measures],
+            *[joined[f"{measure}_previous"] for measure in measures],
+        )
+
+    pct_mutations = {}
+    delta_mutations = {}
+    for measure in measures:
+        current_col = result_tbl[f"{measure}_current"]
+        previous_col = result_tbl[f"{measure}_previous"]
+        delta_expr = current_col.fill_null(0) - previous_col.fill_null(0)
+        delta_mutations[f"{measure}_delta"] = delta_expr
+        pct_mutations[f"{measure}_pct_change"] = delta_expr / previous_col.nullif(0)
+
+    result_tbl = result_tbl.mutate(**delta_mutations, **pct_mutations)
+
+    if order_by:
+        result_tbl = result_tbl.order_by(
+            [
+                result_tbl[field].desc() if direction.lower() == "desc" else result_tbl[field]
+                for field, direction in order_by
+            ]
+        )
+    if limit is not None:
+        result_tbl = result_tbl.limit(limit)
+
+    return to_semantic_table(result_tbl, name=f"{model_name or 'model'}_period_comparison")
+
+
 def query(
     semantic_table: Any,  # SemanticModel, but avoiding circular import
     dimensions: Sequence[str] | None = None,
@@ -655,9 +811,6 @@ def query(
 
     # Step 0: Add time_range as a filter if specified
     if time_range:
-        if not isinstance(time_range, dict) or "start" not in time_range or "end" not in time_range:
-            raise ValueError("time_range must be a dict with 'start' and 'end' keys")
-
         time_dim_name = _find_time_dimension(result, dimensions)
         if not time_dim_name:
             raise ValueError(
@@ -667,17 +820,7 @@ def query(
                 ".with_dimensions(dim_name={'expr': lambda t: t.column, 'is_time_dimension': True})"
             )
 
-        # Apply time range filters using the Dimension object directly.
-        # This uses dim(t) which calls Dimension.__call__ and properly resolves
-        # Deferred expressions (ibis._) via: self.expr.resolve(table) if _is_deferred(...)
-        # This is the same pattern used for time_grain transformations.
-        from datetime import datetime
-
-        dim_obj = result.get_dimensions().get(time_dim_name)
-        start_dt = datetime.fromisoformat(time_range["start"])
-        end_dt = datetime.fromisoformat(time_range["end"])
-        filters.append(lambda t, dim=dim_obj, start=start_dt: dim(t) >= start)
-        filters.append(lambda t, dim=dim_obj, end=end_dt: dim(t) <= end)
+        filters.extend(_build_time_range_filters(result, time_dim_name, time_range))
 
     # Step 1: Handle time grain transformations
     if time_grain and time_grains:

--- a/src/boring_semantic_layer/server/api.py
+++ b/src/boring_semantic_layer/server/api.py
@@ -44,7 +44,39 @@ class QueryRequest(BaseModel):
     chart_spec: dict[str, Any] | None = None
 
     @model_validator(mode="after")
-    def _check_grain_fields(self) -> "QueryRequest":
+    def _check_grain_fields(self) -> QueryRequest:
+        if self.time_grain is not None and self.time_grains is not None:
+            raise ValueError(
+                "Cannot specify both 'time_grain' and 'time_grains'. "
+                "Use 'time_grain' to apply a single grain to all time dimensions, "
+                "or 'time_grains' to specify per-dimension grains."
+            )
+        return self
+
+
+class ComparePeriodsRequest(BaseModel):
+    """HTTP request body for the compare-periods endpoint."""
+
+    model_name: str
+    dimensions: list[str] | None = None
+    measures: list[str]
+    current_time_range: dict[str, str]
+    previous_time_range: dict[str, str]
+    filters: list[dict[str, Any]] | None = None
+    time_dimension: str | None = None
+    time_grain: str | None = None
+    time_grains: dict[str, str] | None = None
+    order_by: list[tuple[str, str]] | None = None
+    limit: int | None = Field(default=None, ge=1, le=100_000)
+    get_records: bool = True
+    records_limit: int | None = Field(default=None, ge=1)
+    get_chart: bool = True
+    chart_backend: str | None = None
+    chart_format: str | None = None
+    chart_spec: dict[str, Any] | None = None
+
+    @model_validator(mode="after")
+    def _check_grain_fields(self) -> ComparePeriodsRequest:
         if self.time_grain is not None and self.time_grains is not None:
             raise ValueError(
                 "Cannot specify both 'time_grain' and 'time_grains'. "
@@ -261,6 +293,38 @@ def create_app(
             time_grain=payload.time_grain,
             time_grains=payload.time_grains,
             time_range=payload.time_range,
+        )
+        response = json.loads(
+            generate_chart_with_data(
+                query_result,
+                get_records=payload.get_records,
+                records_limit=payload.records_limit,
+                get_chart=payload.get_chart,
+                chart_backend=payload.chart_backend,
+                chart_format=payload.chart_format,
+                chart_spec=payload.chart_spec,
+                default_backend="altair",
+            )
+        )
+        if "error" in response:
+            raise HTTPException(status_code=400, detail=response["error"])
+        return response
+
+    @app.post("/compare-periods")
+    def compare_periods(payload: ComparePeriodsRequest, request: Request) -> dict[str, Any]:
+        model = _get_model_or_404(_get_models(request), payload.model_name)
+
+        query_result = model.compare_periods(
+            dimensions=payload.dimensions,
+            measures=payload.measures,
+            current_time_range=payload.current_time_range,
+            previous_time_range=payload.previous_time_range,
+            filters=payload.filters or [],
+            time_dimension=payload.time_dimension,
+            time_grain=payload.time_grain,
+            time_grains=payload.time_grains,
+            order_by=payload.order_by,
+            limit=payload.limit,
         )
         response = json.loads(
             generate_chart_with_data(

--- a/src/boring_semantic_layer/tests/test_query.py
+++ b/src/boring_semantic_layer/tests/test_query.py
@@ -965,6 +965,98 @@ class TestTimeDimensions:
         assert "order_date" in result.columns
         assert "total_amount" in result.columns
 
+    def test_compare_periods_without_grouping(self, sales_data):
+        """compare_periods should work without grouping on the time dimension."""
+        st = (
+            to_semantic_table(sales_data, "sales")
+            .with_dimensions(
+                order_date={
+                    "expr": lambda t: t.order_date,
+                    "is_time_dimension": True,
+                    "smallest_time_grain": "day",
+                },
+            )
+            .with_measures(total_amount=lambda t: t.amount.sum())
+        )
+
+        result = st.compare_periods(
+            measures=["total_amount"],
+            current_time_range={"start": "2024-02-01", "end": "2024-02-29"},
+            previous_time_range={"start": "2024-01-01", "end": "2024-01-29"},
+            time_dimension="order_date",
+        ).execute()
+
+        assert len(result) == 1
+        row = result.iloc[0]
+        assert row["total_amount_current"] == 15950
+        assert row["total_amount_previous"] == 6960
+        assert row["total_amount_delta"] == 8990
+        assert pytest.approx(row["total_amount_pct_change"], rel=1e-9) == 8990 / 6960
+
+    def test_compare_periods_grouped_by_dimension(self, con):
+        """compare_periods should full-outer join grouped dimensions."""
+        revenue_tbl = con.create_table(
+            "period_compare_revenue",
+            pd.DataFrame(
+                {
+                    "order_date": pd.to_datetime(
+                        [
+                            "2024-01-05",
+                            "2024-01-06",
+                            "2024-01-07",
+                            "2024-01-08",
+                            "2024-02-05",
+                            "2024-02-06",
+                            "2024-02-07",
+                        ]
+                    ),
+                    "category": ["A", "A", "B", "D", "A", "B", "C"],
+                    "amount": [10, 20, 30, 70, 40, 50, 60],
+                }
+            ),
+            overwrite=True,
+        )
+        st = (
+            to_semantic_table(revenue_tbl, "revenue")
+            .with_dimensions(
+                order_date={
+                    "expr": lambda t: t.order_date,
+                    "is_time_dimension": True,
+                    "smallest_time_grain": "day",
+                },
+                category=lambda t: t.category,
+            )
+            .with_measures(total_amount=lambda t: t.amount.sum())
+        )
+
+        result = st.compare_periods(
+            dimensions=["category"],
+            measures=["total_amount"],
+            current_time_range={"start": "2024-02-01", "end": "2024-02-29"},
+            previous_time_range={"start": "2024-01-01", "end": "2024-01-31"},
+            order_by=[("total_amount_delta", "desc")],
+            limit=3,
+        ).execute()
+
+        assert list(result["category"]) == ["C", "B", "A"]
+        assert list(result["total_amount_current"].fillna(0)) == [60, 50, 40]
+        assert list(result["total_amount_previous"].fillna(0)) == [0, 30, 30]
+        assert list(result["total_amount_delta"].fillna(0)) == [60, 20, 10]
+        assert pd.isna(result.loc[result["category"] == "C", "total_amount_pct_change"]).iloc[0]
+
+        full_result = st.compare_periods(
+            dimensions=["category"],
+            measures=["total_amount"],
+            current_time_range={"start": "2024-02-01", "end": "2024-02-29"},
+            previous_time_range={"start": "2024-01-01", "end": "2024-01-31"},
+            order_by=[("category", "asc")],
+        ).execute()
+        assert "D" in set(full_result["category"])
+        d_row = full_result.loc[full_result["category"] == "D"].iloc[0]
+        assert pd.isna(d_row["total_amount_current"])
+        assert d_row["total_amount_previous"] == 70
+        assert d_row["total_amount_delta"] == -70
+
 
 class TestFilterErrorHandling:
     """Test error handling in filter validation."""

--- a/src/boring_semantic_layer/tests/test_semantic_mcp.py
+++ b/src/boring_semantic_layer/tests/test_semantic_mcp.py
@@ -200,6 +200,34 @@ class TestGetTimeRange:
                 await client.call_tool("get_time_range", {"model_name": "nonexistent"})
 
 
+class TestComparePeriods:
+    """Test compare_periods tool."""
+
+    @pytest.mark.asyncio
+    async def test_compare_periods_grouped(self, sample_models):
+        mcp = MCPSemanticModel(models=sample_models)
+
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "compare_periods",
+                {
+                    "model_name": "flights",
+                    "dimensions": ["carrier"],
+                    "measures": ["flight_count"],
+                    "current_time_range": {"start": "2024-01-11", "end": "2024-01-20"},
+                    "previous_time_range": {"start": "2024-01-01", "end": "2024-01-10"},
+                    "get_chart": False,
+                },
+            )
+
+            data = json.loads(result.content[0].text)
+            assert "records" in data
+            aa_row = next(row for row in data["records"] if row["carrier"] == "AA")
+            assert aa_row["flight_count_current"] == 3
+            assert aa_row["flight_count_previous"] == 4
+            assert aa_row["flight_count_delta"] == -1
+
+
 class TestQueryModel:
     """Test query_model tool."""
 

--- a/src/boring_semantic_layer/tests/test_server_api.py
+++ b/src/boring_semantic_layer/tests/test_server_api.py
@@ -229,6 +229,34 @@ def test_query_supports_per_dimension_time_grains(client):
     assert data["records"][0]["flight_count"] > 0
 
 
+def test_compare_periods_endpoint(client):
+    response = client.post(
+        "/compare-periods",
+        json={
+            "model_name": "flights",
+            "dimensions": ["carrier"],
+            "measures": ["flight_count"],
+            "current_time_range": {"start": "2024-01-11", "end": "2024-01-20"},
+            "previous_time_range": {"start": "2024-01-01", "end": "2024-01-10"},
+            "get_chart": False,
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["columns"] == [
+        "carrier",
+        "flight_count_current",
+        "flight_count_previous",
+        "flight_count_delta",
+        "flight_count_pct_change",
+    ]
+    aa_row = next(row for row in data["records"] if row["carrier"] == "AA")
+    assert aa_row["flight_count_current"] == 3
+    assert aa_row["flight_count_previous"] == 4
+    assert aa_row["flight_count_delta"] == -1
+
+
 def test_query_rejects_both_time_grain_and_time_grains(client):
     """Specifying both time_grain and time_grains is an error."""
     response = client.post(


### PR DESCRIPTION
## Summary
- add a `compare_periods()` helper on semantic tables for explicit current-vs-previous comparisons
- expose the workflow via MCP and HTTP API so chat agents can answer WoW/MoM/YoY questions in one call
- document the new period-comparison pattern and add regression coverage for core, server, and MCP paths

## Testing
- `PYTHONPATH=src pytest -q src/boring_semantic_layer/tests/test_query.py src/boring_semantic_layer/tests/test_server_api.py src/boring_semantic_layer/tests/test_semantic_mcp.py`

Closes #231.