### PR TITLE
fix: treat UnboundTable as a leaf node in _reconstruct_table

### DIFF
--- a/src/boring_semantic_layer/serialization/reconstruct.py
+++ b/src/boring_semantic_layer/serialization/reconstruct.py
@@ -125,7 +125,7 @@ def _reconstruct_semantic_table(
             base = unbound_tables[0].to_expr()
             return base.view() if is_self_ref else base
 
-        return xorq_expr.to_expr()
+        return xorq_expr
 
     dim_meta = context.parse_field(metadata, "dimensions")
     meas_meta = context.parse_field(metadata, "measures")

--- a/src/boring_semantic_layer/serialization/reconstruct.py
+++ b/src/boring_semantic_layer/serialization/reconstruct.py
@@ -95,9 +95,13 @@ def _reconstruct_semantic_table(
         read_ops = list(walk_nodes((Read,), unwrapped_expr))
         in_memory_tables = list(walk_nodes((xorq_rel.InMemoryTable,), unwrapped_expr))
         db_tables = list(walk_nodes((xorq_rel.DatabaseTable,), unwrapped_expr))
+        unbound_tables = list(walk_nodes((xorq_rel.UnboundTable,), unwrapped_expr))
 
         total_leaf_tables = (
-            len(read_ops) + len(in_memory_tables) + (len(db_tables) if not read_ops else 0)
+            len(read_ops)
+            + len(in_memory_tables)
+            + (len(db_tables) if not read_ops else 0)
+            + len(unbound_tables)
         )
         if total_leaf_tables > 1:
             expr = (
@@ -115,6 +119,10 @@ def _reconstruct_semantic_table(
 
         if db_tables:
             base = db_tables[0].to_expr()
+            return base.view() if is_self_ref else base
+
+        if unbound_tables:
+            base = unbound_tables[0].to_expr()
             return base.view() if is_self_ref else base
 
         return xorq_expr.to_expr()

--- a/src/boring_semantic_layer/serialization/reconstruct.py
+++ b/src/boring_semantic_layer/serialization/reconstruct.py
@@ -125,7 +125,7 @@ def _reconstruct_semantic_table(
             base = unbound_tables[0].to_expr()
             return base.view() if is_self_ref else base
 
-        return xorq_expr
+        return xorq_expr.to_expr()
 
     dim_meta = context.parse_field(metadata, "dimensions")
     meas_meta = context.parse_field(metadata, "measures")

--- a/src/boring_semantic_layer/tests/test_xorq_string_serialization.py
+++ b/src/boring_semantic_layer/tests/test_xorq_string_serialization.py
@@ -1817,3 +1817,26 @@ def test_tagged_roundtrip_join_chain_shared_column_names(n_joins):
     assert len(result) == len(baseline)
     assert list(result["carriers.nickname"]) == list(baseline["carriers.nickname"])
     assert list(result["flights.flight_count"]) == list(baseline["flights.flight_count"])
+
+
+def test_tagged_roundtrip_unbound_table():
+    """Round-trip serialization works for tables backed by an UnboundTable (no concrete data source)."""
+    from xorq.vendor import ibis
+
+    from boring_semantic_layer.serialization import from_tagged, to_tagged
+
+    t = ibis.table(
+        {"origin": "string", "destination": "string", "distance": "int64"},
+        name="flights",
+    )
+    flights = (
+        to_semantic_table(t, name="flights")
+        .with_dimensions(origin=lambda t: t.origin)
+        .with_measures(total_distance=lambda t: t.distance.sum())
+    )
+
+    tagged = to_tagged(flights)
+    reconstructed = from_tagged(tagged)
+
+    assert set(reconstructed.op().get_dimensions().keys()) == {"origin"}
+    assert set(reconstructed.op().get_measures().keys()) == {"total_distance"}


### PR DESCRIPTION
## Summary
- `_reconstruct_table()` walks the expression tree looking for leaf nodes (Read, InMemoryTable, DatabaseTable) but did not recognize `UnboundTable`
- Add `UnboundTable` to the set of recognized leaf node types, handled the same way as `DatabaseTable`

Closes #240

## Test plan
- [x] Added `test_tagged_roundtrip_unbound_table` — creates a semantic table from an `UnboundTable` and verifies round-trip through `to_tagged`/`from_tagged`

🤖 Generated with [Claude Code](https://claude.com/claude-code)