### PR TITLE
fix: guard join rebind against non-xorq backends (#242)

### DIFF
--- a/src/boring_semantic_layer/ops.py
+++ b/src/boring_semantic_layer/ops.py
@@ -4003,12 +4003,22 @@ class SemanticJoinOp(Relation):
         backends found" unless all tables in a join share the same instance.
         Uses ``op.replace()`` (ibis graph rewriting) to swap out the
         ``source`` field on every ``DatabaseTable`` node in the right tree.
+
+        For plain ibis expressions (backends xorq doesn't wrap, e.g.
+        BigQuery), ``walk_nodes`` can't traverse the tree — fall back to
+        returning the inputs unchanged so ibis executes the join natively.
         """
-        from xorq.common.utils.node_utils import walk_nodes
-        from xorq.vendor.ibis.expr.operations import relations as xorq_rel
+        try:
+            from xorq.common.utils.node_utils import walk_nodes
+            from xorq.vendor.ibis.expr.operations import relations as xorq_rel
+        except Exception:
+            return left_tbl, right_tbl
 
         # Find a canonical backend from the left tree.
-        db_tables = list(walk_nodes((xorq_rel.DatabaseTable,), left_tbl))
+        try:
+            db_tables = list(walk_nodes((xorq_rel.DatabaseTable,), left_tbl))
+        except Exception:
+            return left_tbl, right_tbl
         canonical = db_tables[0].source if db_tables else None
 
         if canonical is None:

--- a/src/boring_semantic_layer/tests/test_plain_ibis.py
+++ b/src/boring_semantic_layer/tests/test_plain_ibis.py
@@ -171,6 +171,26 @@ class TestPlainIbisJoins:
         assert len(result) == 3
         assert "name" in result.columns
 
+    def test_join_one_unsupported_backend(
+        self, flights_model, carriers_model, monkeypatch
+    ):
+        """Simulate a backend xorq cannot wrap (e.g. BigQuery) by forcing
+        ``_ensure_xorq_table`` to return the plain ibis table. The join
+        must still execute natively rather than crashing inside
+        ``_rebind_join_backends``. See issue #242.
+        """
+        from boring_semantic_layer import ops
+
+        monkeypatch.setattr(ops, "_ensure_xorq_table", lambda table: table)
+
+        joined = flights_model.join_one(
+            carriers_model,
+            on=lambda f, c: f.carrier == c.code,
+        )
+        result = joined.group_by("name").aggregate("flight_count").execute()
+        assert len(result) == 3
+        assert "name" in result.columns
+
 
 class TestPlainIbisSerializationGating:
     """Serialization features raise clear errors for non-xorq backends."""


### PR DESCRIPTION
## Summary
- Joins on plain ibis backends xorq can't wrap (BigQuery, Databricks, …) crashed inside `_rebind_join_backends` with `ValueError: Don't know how to handle type <class 'ibis.expr.types.relations.Table'>` from xorq's `walk_nodes`.
- Mirror the `try/except` guard already used by `_unify_backends` so the rebind is skipped for plain ibis trees, letting ibis execute the join natively.
- Add a regression test that forces `_ensure_xorq_table` to return a plain ibis table (simulating BigQuery's unsupported wrapping path) and verifies `join_one` still executes end-to-end.

Fixes #242.

## Test plan
- [x] `uv run pytest src/boring_semantic_layer/tests/test_plain_ibis.py` — 12 passed, including new `test_join_one_unsupported_backend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)