### PR TITLE
fix: walk join branches in tag_handler.extract_metadata

### DIFF
--- a/src/boring_semantic_layer/serialization/tag_handler.py
+++ b/src/boring_semantic_layer/serialization/tag_handler.py
@@ -29,22 +29,49 @@ from .freeze import thaw
 def extract_metadata(tag_node) -> dict[str, Any]:
     """Return sidecar metadata (dimension/measure names) for a BSL-tagged node.
 
-    Walks nested metadata (the ``source`` chain) down to the innermost
-    ``SemanticTableOp`` and extracts the dimension/measure name tuples.
+    Walks nested metadata down to every ``SemanticTableOp`` leaf and unions
+    their dimension / measure / calc-measure names. ``source`` chains are
+    descended through; ``SemanticJoinOp`` nodes branch into ``left`` and
+    ``right``. Names from a joined leaf are prefixed with the leaf's table
+    name (matching how a joined ``SemanticTable`` exposes its fields, e.g.
+    ``flights.flight_count``); a non-joined model returns flat names.
     """
-    table_meta: Any = tag_node.metadata
-    while table_meta.get("bsl_op_type") != "SemanticTableOp" and (
-        src := table_meta.get("source")
-    ):
-        table_meta = dict(src) if isinstance(src, tuple) else src
-    dims = tuple(d[0] for d in table_meta.get("dimensions", ()))
-    measures = tuple(m[0] for m in table_meta.get("measures", ()))
-    return {
+
+    def as_dict(meta: Any) -> dict[str, Any]:
+        return dict(meta) if isinstance(meta, tuple) else meta
+
+    def collect(meta: Any, *, in_join: bool) -> tuple[list[str], list[str], list[str]]:
+        meta = as_dict(meta)
+        op_type = meta.get("bsl_op_type")
+
+        if (src := meta.get("source")) is not None:
+            return collect(src, in_join=in_join)
+
+        if op_type == "SemanticJoinOp":
+            ld, lm, lc = collect(meta.get("left", {}), in_join=True)
+            rd, rm, rc = collect(meta.get("right", {}), in_join=True)
+            return ld + rd, lm + rm, lc + rc
+
+        if op_type == "SemanticTableOp":
+            name = meta.get("name")
+            prefix = f"{name}." if (in_join and name) else ""
+            dims = [prefix + d[0] for d in meta.get("dimensions", ())]
+            meas = [prefix + m[0] for m in meta.get("measures", ())]
+            calc = [prefix + c[0] for c in meta.get("calc_measures", ())]
+            return dims, meas, calc
+
+        return [], [], []
+
+    dims, measures, calc = collect(tag_node.metadata, in_join=False)
+    result: dict[str, Any] = {
         "type": "semantic_model",
         "description": f"{len(dims)} dims, {len(measures)} measures",
-        "dimensions": dims,
-        "measures": measures,
+        "dimensions": tuple(dims),
+        "measures": tuple(measures),
     }
+    if calc:
+        result["calc_measures"] = tuple(calc)
+    return result
 
 
 def from_tag_node(tag_node):

--- a/src/boring_semantic_layer/tests/test_xorq_tag_handler.py
+++ b/src/boring_semantic_layer/tests/test_xorq_tag_handler.py
@@ -17,7 +17,7 @@ import importlib.metadata
 import ibis
 import pytest
 
-from boring_semantic_layer import SemanticModel
+from boring_semantic_layer import SemanticModel, to_semantic_table
 from boring_semantic_layer.serialization import to_tagged
 from boring_semantic_layer.serialization.tag_handler import (
     bsl_tag_handler,
@@ -112,6 +112,54 @@ def test_extract_metadata_walks_source_chain(simple_model):
     # Names come from the base model, not just the projected query columns.
     assert set(meta["dimensions"]) == {"a", "b"}
     assert set(meta["measures"]) == {"sum_b", "avg_b"}
+
+
+def test_extract_metadata_walks_join_branches():
+    """For joined models the handler must descend into both ``left`` and
+    ``right`` branches and union dim/measure names from every leaf
+    ``SemanticTableOp``, prefixing them with the leaf's table name to match
+    how a joined ``SemanticTable`` exposes its fields."""
+    t1 = ibis.memtable({"id": [1, 2], "name": ["a", "b"]})
+    t2 = ibis.memtable({"id": [1, 2], "value": [10, 20]})
+    t3 = ibis.memtable({"id": [1, 2], "extra": ["x", "y"]})
+
+    st1 = (
+        to_semantic_table(t1, name="t1")
+        .with_dimensions(id=lambda t: t.id, name=lambda t: t.name)
+        .with_measures(count=lambda t: t.count())
+    )
+    st2 = (
+        to_semantic_table(t2, name="t2")
+        .with_dimensions(id=lambda t: t.id)
+        .with_measures(total=lambda t: t.value.sum())
+    )
+    st3 = (
+        to_semantic_table(t3, name="t3")
+        .with_dimensions(id=lambda t: t.id, extra=lambda t: t.extra)
+        .with_measures(extra_count=lambda t: t.count())
+    )
+
+    # Two-arm join chain: covers nested SemanticJoinOp on the left as well as
+    # a query wrapper on top, exercising the same path as the original bug
+    # where every leaf was being missed.
+    joined = st1.join_one(st2, on=lambda l, r: l.id == r.id).join_one(
+        st3, on=lambda l, r: l.id == r.id
+    )
+    query = joined.query(dimensions=("t1.name",), measures=("t1.count",))
+    tag_node = _tag_node(to_tagged(query))
+
+    meta = extract_metadata(tag_node)
+
+    assert set(meta["dimensions"]) == {
+        "t1.id",
+        "t1.name",
+        "t2.id",
+        "t3.id",
+        "t3.extra",
+    }
+    assert set(meta["measures"]) == {"t1.count", "t2.total", "t3.extra_count"}
+    assert "5 dims" in meta["description"]
+    assert "3 measures" in meta["description"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `tag_handler.extract_metadata` walked only the `source` chain looking for the innermost `SemanticTableOp`. For joined models the tag tree branches via `SemanticJoinOp.left` / `.right` (no `source`), so the walk stopped at the join op and the catalog summary returned `"0 dims, 0 measures"` and empty `dimensions`/`measures` arrays — even though every leaf `SemanticTableOp`'s metadata was intact further down the tree.
- Rewrote the walker to recurse through `source`, fan out into both branches of any `SemanticJoinOp`, and union dim/measure/calc-measure names from every `SemanticTableOp` leaf. Inside a join subtree, names are prefixed with the leaf's table name so the catalog summary matches the field names a joined `SemanticTable` exposes (e.g. `flights.flight_count`); single-table models still emit flat names so the existing base-model tests continue to hold.
- Calc measures are now also surfaced in the summary when present.

## Scope

Audited the rest of the codebase for the same source-only blind spot — none found:

- `from_tag_node` walks `source` only, but that's intentional: it strips off query wrappers down to the base op, then the `_reconstruct_join` reconstructor handles `left`/`right` itself.
- `reemit` operates on `tag_node.parent`, doesn't traverse metadata.
- `chart/utils.py` walkers operate on live op trees and use `_get_merged_fields` / `_find_all_root_models`, which already handle joins.
- All linear ops (`SemanticFilterOp`, `SemanticProjectOp`, `SemanticGroupByOp`, `SemanticAggregateOp`, `SemanticMutateOp`, `SemanticOrderByOp`, `SemanticLimitOp`, `SemanticUnnestOp`, `SemanticIndexOp`) have a single `source` and pass through correctly.

## Test plan

- [x] `nix develop .#impure` + `uv run python -m pytest src/boring_semantic_layer/tests/test_xorq_tag_handler.py` — 9 passed (8 existing + 1 new)
- [x] `nix develop .#impure` + `uv run python -m pytest src/boring_semantic_layer/tests/test_xorq_tag_handler.py src/boring_semantic_layer/tests/test_xorq_rebuild.py src/boring_semantic_layer/tests/test_xorq_convert.py src/boring_semantic_layer/tests/test_xorq_integration.py` — 31 passed, 14 skipped, 1 xfailed
- [x] New regression test `test_extract_metadata_walks_join_branches` covers a two-arm `join_one` chain wrapped in a query and asserts the union of prefixed dim/measure names (`{t1.id, t1.name, t2.id, t3.id, t3.extra}` and `{t1.count, t2.total, t3.extra_count}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)