### PR TITLE
fix: preserve preagg + canonical backend through with_measures on joins

### DIFF
--- a/src/boring_semantic_layer/expr.py
+++ b/src/boring_semantic_layer/expr.py
@@ -109,12 +109,14 @@ _BLOCKED_IBIS_METHODS = [
 
 
 def to_untagged(expr):
+    from .ops import _rebind_to_canonical_backend
+
     if isinstance(expr, SemanticTable):
-        return expr.op().to_untagged()
+        return _rebind_to_canonical_backend(expr.op().to_untagged())
 
     result = safe(lambda: expr.to_untagged())()
     if isinstance(result, Success):
-        return result.unwrap()
+        return _rebind_to_canonical_backend(result.unwrap())
 
     raise TypeError(f"Cannot convert {type(expr)} to Ibis expression")
 

--- a/src/boring_semantic_layer/ops.py
+++ b/src/boring_semantic_layer/ops.py
@@ -2510,7 +2510,13 @@ class SemanticAggregateOp(Relation):
             )
 
         # --- 3. Partition agg_specs by source table ---
-        partitioned = _partition_agg_specs_by_source(dict(plan.agg_specs), all_roots)
+        # Partition by the join's per-table roots, not ``all_roots``. When a
+        # wrapper SemanticTableOp from ``SemanticJoin.with_measures()`` /
+        # ``with_dimensions()`` is in the tree, ``all_roots`` collapses to a
+        # single name=None root, so prefixed aggregates would all fall into the
+        # unprefixed bucket and bypass per-grain pre-aggregation.
+        partition_roots = _find_all_root_models(join_op)
+        partitioned = _partition_agg_specs_by_source(dict(plan.agg_specs), partition_roots)
 
         # --- 4. Pre-aggregate each source table on its raw table ---
         _preagg_results: list = []


### PR DESCRIPTION
## Summary

- **ops.py**: `SemanticJoin.with_measures()` / `with_dimensions()` wraps the join in a `SemanticTableOp` with `name=None`. Pre-agg partitioning used `all_roots = [wrapper]`, so prefixed aggregates collapsed into the unprefixed bucket and bypassed per-grain pre-aggregation — fanning out the coarser table by the finer table's row count. Fix: partition by `_find_all_root_models(join_op)` instead.
- **expr.py**: `to_untagged()` / `to_tagged()` returned expressions that raised `XorqError: Multiple backends found` on `.execute()`, even though `SemanticTable.execute()` worked (it already wraps with `_rebind_to_canonical_backend`). Apply the same rebind inside `to_untagged()`; `to_tagged()` benefits transitively.

## Test plan

- [x] 941 tests pass (1 pre-existing unrelated failure excluded)
- [x] `expr.execute()`, `to_untagged(expr).execute()`, `to_tagged(expr).execute()` all return correct numbers for grain-matched and grain-mismatched joins

🤖 Generated with [Claude Code](https://claude.com/claude-code)