### PR TITLE
chore: prepare v0.3.14 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boring-semantic-layer"
-version = "0.3.13"
+version = "0.3.14"
 description = "A boring semantic layer built with ibis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "boring-semantic-layer"
-version = "0.3.12"
+version = "0.3.14"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
Patch bump to **v0.3.14**.

## Included PRs (since v0.3.13)

- #222 — fix: handle plain ibis backends in join backend rebinding (fixes #221, Snowflake/Databricks/BigQuery)
- #261 — fix: preserve preagg + canonical backend through `with_measures` on joins
- #262 — Unify calc measures on ibis-native classifier (ADR 0001 phases 1+2)
- #264 — fix(serialization): use `HashingTag` so BSL metadata contributes to content hash

## After merge

1. Tag `v0.3.14` on main
2. Push tag (triggers PyPI release workflow)
3. Create GitHub release using `.tmp_release_body_v0.3.14.md` from the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)