### PR TITLE
test: prefer public ibis window in demo and chart regression

### DIFF
--- a/examples/bucketing_with_other.py
+++ b/examples/bucketing_with_other.py
@@ -6,7 +6,7 @@ Malloy: https://docs.malloydata.dev/documentation/patterns/other
 
 from pathlib import Path
 
-import xorq.api as xo
+import ibis
 from ibis import _
 
 from boring_semantic_layer import from_yaml
@@ -28,13 +28,13 @@ def main():
             nest={"data": lambda t: t.group_by(["code", "elevation"])},
         )
         .mutate(
-            rank=lambda t: xo.row_number().over(
-                xo.window(order_by=xo.desc(t.avg_elevation)),
+            rank=lambda t: ibis.row_number().over(
+                ibis.window(order_by=ibis.desc(t.avg_elevation)),
             ),
         )
         .mutate(
             is_other=lambda t: t.rank > 4,
-            state_grouped=lambda t: xo.ifelse(t.rank > 4, "OTHER", t.state),
+            state_grouped=lambda t: ibis.ifelse(t.rank > 4, "OTHER", t.state),
         )
         .group_by("state_grouped")
         .aggregate(

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -12,7 +12,6 @@ This script showcases:
 
 import ibis
 import pandas as pd
-import xorq.api as xo
 
 from boring_semantic_layer import to_semantic_table
 
@@ -112,7 +111,7 @@ def main():
         .with_measures(sum_val=lambda t: t.value.sum())
     )
 
-    rolling_window = xo.window(order_by="date", rows=(1, 1))
+    rolling_window = ibis.window(order_by="date", rows=(1, 1))
     expr4 = (
         ts_st.group_by("date")
         .aggregate("sum_val")

--- a/examples/sessionized_data.py
+++ b/examples/sessionized_data.py
@@ -12,7 +12,6 @@ from pathlib import Path
 
 import ibis
 import pandas as pd
-import xorq.api as xo
 
 from boring_semantic_layer import from_yaml, to_untagged
 
@@ -32,7 +31,7 @@ def main():
 
     # Filter for carrier WN on 2002-03-03 and add flight_date column
     filtered_flights = flights.filter(
-        lambda t: (t.carrier == "WN") & (t.dep_time.date() == xo.date(2002, 3, 3)),
+        lambda t: (t.carrier == "WN") & (t.dep_time.date() == ibis.date(2002, 3, 3)),
     ).mutate(flight_date=lambda t: t.dep_time.date())
 
     # Create sessions with nested flight legs
@@ -53,7 +52,7 @@ def main():
                 ]),
             },
         )
-        .mutate(session_id=xo.row_number().over(xo.window()))
+        .mutate(session_id=ibis.row_number().over(ibis.window()))
         .order_by("session_id")
     )
 

--- a/examples/window_functions.py
+++ b/examples/window_functions.py
@@ -2,7 +2,6 @@
 """Window Functions - Rolling Averages, Rankings, Running Totals, and t.all()."""
 
 import ibis
-import xorq.api as xo
 from ibis import _
 
 from boring_semantic_layer import to_semantic_table
@@ -32,13 +31,13 @@ def main():
     result = (
         daily_stats.mutate(
             rolling_avg=lambda t: t.flight_count.mean().over(
-                xo.window(order_by=t.flight_date, preceding=6, following=0),
+                ibis.window(order_by=t.flight_date, preceding=6, following=0),
             ),
-            rank=lambda t: xo.dense_rank().over(
-                xo.window(order_by=xo.desc(t.flight_count)),
+            rank=lambda t: ibis.dense_rank().over(
+                ibis.window(order_by=ibis.desc(t.flight_count)),
             ),
             running_total=lambda t: t.flight_count.sum().over(
-                xo.window(order_by=t.flight_date),
+                ibis.window(order_by=t.flight_date),
             ),
         )
         .order_by("flight_date")
@@ -65,8 +64,8 @@ def main():
 
     result = (
         carrier_stats.mutate(
-            total_flights=lambda t: t.flight_count.sum().over(xo.window()),
-            percent_manual=lambda t: (t.flight_count / t.flight_count.sum().over(xo.window()))
+            total_flights=lambda t: t.flight_count.sum().over(ibis.window()),
+            percent_manual=lambda t: (t.flight_count / t.flight_count.sum().over(ibis.window()))
             * 100,
         )
         .order_by(_.percent_manual.desc())

--- a/scripts/demo_bsl_v2.py
+++ b/scripts/demo_bsl_v2.py
@@ -20,11 +20,6 @@ if __package__ in {None, ""}:
 
 from boring_semantic_layer import to_semantic_table
 
-# BSL's to_untagged() returns xorq-vendored ibis when xorq is installed, and
-# those expressions reject a plain ibis.window (LegacyWindowBuilder). Build the
-# window from the matching flavor via the shim (plain ibis when xorq is absent).
-from boring_semantic_layer._xorq import ibis as xibis
-
 
 def main():
     # Setup in-memory DuckDB
@@ -121,7 +116,7 @@ def main():
         .with_measures(sum_val=lambda t: t.value.sum())
     )
 
-    rolling_window = xibis.window(order_by="date", preceding=1, following=1)
+    rolling_window = ibis.window(order_by="date", preceding=1, following=1)
     expr4 = (
         ts_st.group_by("date")
         .aggregate("sum_val")

--- a/src/boring_semantic_layer/chart/tests/test_chart.py
+++ b/src/boring_semantic_layer/chart/tests/test_chart.py
@@ -9,7 +9,6 @@ from boring_semantic_layer import to_semantic_table
 # BSL's to_untagged() returns xorq-vendored ibis when xorq is installed, and
 # those expressions reject a plain ibis.window (LegacyWindowBuilder). Build the
 # window from the matching flavor via the shim (plain ibis when xorq is absent).
-from boring_semantic_layer._xorq import ibis as xibis
 
 
 @pytest.fixture(scope="module")
@@ -391,7 +390,7 @@ class TestChartWithFilters:
             .order_by("flight_week")
             .mutate(
                 rolling_avg=lambda t: t.flight_count.mean().over(
-                    xibis.window(rows=(-2, 0), order_by="flight_week")
+                    ibis.window(rows=(-2, 0), order_by="flight_week")
                 )
             )
         )

--- a/src/boring_semantic_layer/ops.py
+++ b/src/boring_semantic_layer/ops.py
@@ -740,6 +740,11 @@ def _classify_measure(
     if prefer_known is None:
         prefer_known = getattr(scope, "_prefer_known", ())
     prefer_known_set = frozenset(prefer_known)
+    expr_prefer_known = getattr(expr, "__bsl_prefer_known__", ())
+    if expr_prefer_known is True:
+        prefer_known_set = prefer_known_set | known_set
+    else:
+        prefer_known_set = prefer_known_set | frozenset(expr_prefer_known or ())
 
     # Pure constants fold into both grouped and ungrouped contexts.
     if isinstance(expr, (int, float)) and not isinstance(expr, bool):

--- a/src/boring_semantic_layer/tests/integration/conftest.py
+++ b/src/boring_semantic_layer/tests/integration/conftest.py
@@ -13,10 +13,11 @@ import pandas as pd
 import pytest
 from toolz import curry
 
-# The Malloy comparison fixtures load BSL query modules (``malloy_data/*.py``)
-# that import ``xorq.api`` directly, so the whole directory requires xorq. Skip
-# collecting it when xorq is absent (the no-xorq CI leg) rather than relying on a
-# ``--ignore`` CLI flag, so the gate lives with the tests that need it.
+# Several Malloy comparison query modules under ``malloy_data/*.py`` import
+# ``xorq.api`` directly, and the parametrized integration suite includes those
+# modules. Skip collecting the integration directory when xorq is absent (the
+# no-xorq CI leg) rather than relying on a ``--ignore`` CLI flag, so the gate
+# lives with the tests that need it.
 try:
     import xorq  # noqa: F401
 except ImportError:

--- a/src/boring_semantic_layer/tests/test_yaml.py
+++ b/src/boring_semantic_layer/tests/test_yaml.py
@@ -1436,6 +1436,53 @@ def test_yaml_calculated_measures_simple_format(duckdb_conn):
     assert "ratio" in df.columns
 
 
+def test_yaml_calculated_measures_prefer_same_named_measures(duckdb_conn):
+    """YAML calculated measures resolve colliding names to measures, not raw columns."""
+    tbl = duckdb_conn.create_table(
+        "calc_meas_collision_tbl",
+        {
+            "phase": ["approved", "approved", "review"],
+            "required_people": [10, 20, 5],
+            "scheduled_people": [12, 18, 10],
+            "target_cells": [2, 3, 1],
+        },
+    )
+
+    config = {
+        "targets": {
+            "table": "calc_meas_collision_tbl",
+            "dimensions": {"phase": "_.phase"},
+            "measures": {
+                "target_cells": "_.target_cells.sum()",
+                "required_people": "_.required_people.sum()",
+                "scheduled_people": "_.scheduled_people.sum()",
+            },
+            "calculated_measures": {
+                "coverage_ratio": "_.scheduled_people / _.required_people",
+                "avg_required_per_cell": "_.required_people / _.target_cells",
+            },
+        },
+    }
+
+    model = from_config(config, tables={"calc_meas_collision_tbl": tbl})["targets"]
+    assert set(model.get_calculated_measures()) == {
+        "coverage_ratio",
+        "avg_required_per_cell",
+    }
+
+    df = (
+        model.query(
+            dimensions=("phase",),
+            measures=("coverage_ratio", "avg_required_per_cell"),
+        )
+        .execute()
+        .sort_values("phase")
+        .reset_index(drop=True)
+    )
+    assert df["coverage_ratio"].tolist() == pytest.approx([1.0, 2.0])
+    assert df["avg_required_per_cell"].tolist() == pytest.approx([6.0, 5.0])
+
+
 # ---------------------------------------------------------------------------
 # Issue #115: .all() for window aggregations in YAML
 # ---------------------------------------------------------------------------

--- a/src/boring_semantic_layer/yaml.py
+++ b/src/boring_semantic_layer/yaml.py
@@ -84,6 +84,12 @@ def _parse_calc_measure(name: str, config: str | dict) -> Measure:
     def _make_calc_fn(source: str):
         def calc_fn(scope):
             return safe_eval(source, context={"_": scope}).unwrap()
+
+        # YAML ``calculated_measures`` are documented as expressions over
+        # measures, not raw columns. Prefer known measure names during calc
+        # classification so a measure named like its source column (the common
+        # ``revenue: _.revenue.sum()`` shape) resolves to the aggregate output.
+        calc_fn.__bsl_prefer_known__ = True
         return calc_fn
 
     measure_kwargs = {"metadata": extra_kwargs["metadata"]} if "metadata" in extra_kwargs else {}


### PR DESCRIPTION
## Summary
- use public plain `ibis.window(...)` in the user-facing demo
- use public `ibis.window(...)` in examples that do not need xorq (`quickstart.py`, `window_functions.py`, `bucketing_with_other.py`, `sessionized_data.py`)
- use public `ibis.window(...)` in the chart rolling-window regression
- clarify the integration-suite xorq skip comment: several Malloy query modules import xorq directly, not every module
- fix YAML `calculated_measures` whose names collide with source columns used by base measures

## Root cause for YAML fix
`IbisCalcScope` intentionally resolves base columns before measures on name collisions. YAML `calculated_measures` are documented as expressions over measures, but the parser did not tell the classifier to prefer known measures. For common configs like `required_people: _.required_people.sum()`, the calculated measure `_.scheduled_people / _.required_people` was misclassified as a base expression over raw columns, then failed during aggregation/projection with an Ibis relation `IntegrityError`.

## Validation
- `python scripts/demo_bsl_v2.py`
- `PYTHONPATH=/tmp/block_xorq python scripts/demo_bsl_v2.py`
- `PYTHONPATH=src python examples/quickstart.py`
- `PYTHONPATH=/tmp/block_xorq:src python examples/quickstart.py`
- `PYTHONPATH=src python examples/window_functions.py`
- `PYTHONPATH=/tmp/block_xorq:src python examples/window_functions.py`
- `PYTHONPATH=src python examples/bucketing_with_other.py`
- `PYTHONPATH=/tmp/block_xorq:src python examples/bucketing_with_other.py`
- `PYTHONPATH=src python examples/sessionized_data.py`
- `PYTHONPATH=/tmp/block_xorq:src python examples/sessionized_data.py`
- `PYTHONPATH=/tmp/block_xorq:src python -m pytest src/boring_semantic_layer/tests/test_yaml.py::test_yaml_calculated_measures_prefer_same_named_measures src/boring_semantic_layer/tests/test_yaml.py::test_yaml_calculated_measures_simple_format src/boring_semantic_layer/tests/test_yaml.py::test_yaml_all_window_aggregation src/boring_semantic_layer/chart/tests/test_chart.py::TestChartWithFilters::test_chart_with_dynamic_dimension_and_rolling_window -q`
- `PYTHONPATH=/tmp/block_xorq:/tmp/bsl-pr278/src python /home/ubuntu/projects/analytics-w0/packages/core/bi/playground/scripts/repro_bsl_278_derived_measure_bug.py` now reaches the "BUG NOT REPRODUCED" success path
