### PR TITLE
fix: resolve YAML calculated measures against measures first

### DIFF
--- a/src/boring_semantic_layer/ops.py
+++ b/src/boring_semantic_layer/ops.py
@@ -740,6 +740,11 @@ def _classify_measure(
     if prefer_known is None:
         prefer_known = getattr(scope, "_prefer_known", ())
     prefer_known_set = frozenset(prefer_known)
+    expr_prefer_known = getattr(expr, "__bsl_prefer_known__", ())
+    if expr_prefer_known is True:
+        prefer_known_set = prefer_known_set | known_set
+    else:
+        prefer_known_set = prefer_known_set | frozenset(expr_prefer_known or ())
 
     # Pure constants fold into both grouped and ungrouped contexts.
     if isinstance(expr, (int, float)) and not isinstance(expr, bool):

--- a/src/boring_semantic_layer/tests/test_yaml.py
+++ b/src/boring_semantic_layer/tests/test_yaml.py
@@ -1436,6 +1436,53 @@ def test_yaml_calculated_measures_simple_format(duckdb_conn):
     assert "ratio" in df.columns
 
 
+def test_yaml_calculated_measures_prefer_same_named_measures(duckdb_conn):
+    """YAML calculated measures resolve colliding names to measures, not raw columns."""
+    tbl = duckdb_conn.create_table(
+        "calc_meas_collision_tbl",
+        {
+            "phase": ["approved", "approved", "review"],
+            "required_people": [10, 20, 5],
+            "scheduled_people": [12, 18, 10],
+            "target_cells": [2, 3, 1],
+        },
+    )
+
+    config = {
+        "targets": {
+            "table": "calc_meas_collision_tbl",
+            "dimensions": {"phase": "_.phase"},
+            "measures": {
+                "target_cells": "_.target_cells.sum()",
+                "required_people": "_.required_people.sum()",
+                "scheduled_people": "_.scheduled_people.sum()",
+            },
+            "calculated_measures": {
+                "coverage_ratio": "_.scheduled_people / _.required_people",
+                "avg_required_per_cell": "_.required_people / _.target_cells",
+            },
+        },
+    }
+
+    model = from_config(config, tables={"calc_meas_collision_tbl": tbl})["targets"]
+    assert set(model.get_calculated_measures()) == {
+        "coverage_ratio",
+        "avg_required_per_cell",
+    }
+
+    df = (
+        model.query(
+            dimensions=("phase",),
+            measures=("coverage_ratio", "avg_required_per_cell"),
+        )
+        .execute()
+        .sort_values("phase")
+        .reset_index(drop=True)
+    )
+    assert df["coverage_ratio"].tolist() == pytest.approx([1.0, 2.0])
+    assert df["avg_required_per_cell"].tolist() == pytest.approx([6.0, 5.0])
+
+
 # ---------------------------------------------------------------------------
 # Issue #115: .all() for window aggregations in YAML
 # ---------------------------------------------------------------------------

--- a/src/boring_semantic_layer/yaml.py
+++ b/src/boring_semantic_layer/yaml.py
@@ -84,6 +84,12 @@ def _parse_calc_measure(name: str, config: str | dict) -> Measure:
     def _make_calc_fn(source: str):
         def calc_fn(scope):
             return safe_eval(source, context={"_": scope}).unwrap()
+
+        # YAML ``calculated_measures`` are documented as expressions over
+        # measures, not raw columns. Prefer known measure names during calc
+        # classification so a measure named like its source column (the common
+        # ``revenue: _.revenue.sum()`` shape) resolves to the aggregate output.
+        calc_fn.__bsl_prefer_known__ = True
         return calc_fn
 
     measure_kwargs = {"metadata": extra_kwargs["metadata"]} if "metadata" in extra_kwargs else {}


### PR DESCRIPTION
## Summary
- fix YAML `calculated_measures` whose names collide with source columns used by base measures
- mark YAML calculated-measure lambdas to prefer known measures during calc classification
- add regression coverage for same-named raw columns/measures (`scheduled_people / required_people`)

## Root cause
`IbisCalcScope` intentionally resolves base columns before measures on name collisions. YAML `calculated_measures` are documented as expressions over measures, but the parser did not tell the classifier to prefer known measures. For common configs like `required_people: _.required_people.sum()`, the calculated measure `_.scheduled_people / _.required_people` was misclassified as a base expression over raw columns, then failed during aggregation/projection with an Ibis relation `IntegrityError`.

## Validation
- `PYTHONPATH=/tmp/block_xorq:/tmp/bsl-pr278/src python /home/ubuntu/projects/analytics-w0/packages/core/bi/playground/scripts/repro_bsl_278_derived_measure_bug.py` now reaches the "BUG NOT REPRODUCED" success path
- `PYTHONPATH=/tmp/block_xorq:src python -m pytest src/boring_semantic_layer/tests/test_yaml.py::test_yaml_calculated_measures_prefer_same_named_measures src/boring_semantic_layer/tests/test_yaml.py::test_yaml_calculated_measures_simple_format src/boring_semantic_layer/tests/test_yaml.py::test_yaml_all_window_aggregation -q`
- `PYTHONPATH=src python -m pytest src/boring_semantic_layer/tests/test_yaml.py::test_yaml_calculated_measures_prefer_same_named_measures src/boring_semantic_layer/tests/test_yaml.py::test_yaml_calculated_measures_simple_format src/boring_semantic_layer/tests/test_yaml.py::test_yaml_all_window_aggregation -q`
